### PR TITLE
feat: change check_can_send to public

### DIFF
--- a/contracts/cw721-base/src/execute.rs
+++ b/contracts/cw721-base/src/execute.rs
@@ -338,7 +338,7 @@ where
     }
 
     /// returns true iff the sender can transfer ownership of the token
-    fn check_can_send(
+    pub fn check_can_send(
         &self,
         deps: Deps,
         env: &Env,


### PR DESCRIPTION
Open up `check_can_send` to allow extensions to implement custom transfer logic.