### PR TITLE
v0.10.0

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+wasm-debug = "build --target wasm32-unknown-unknown"
+unit-test = "test --lib"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "cw721"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -181,7 +181,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-base"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-metadata-onchain"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/cw721-base/Cargo.toml
+++ b/contracts/cw721-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw721-base"
-version = "0.9.3"
+version = "0.10.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Basic implementation cw721 NFTs"
@@ -27,7 +27,7 @@ library = []
 [dependencies]
 cw0 = { version = "0.10.2" }
 cw2 = { version = "0.10.2" }
-cw721 = { path = "../../packages/cw721", version = "0.9.3" }
+cw721 = { path = "../../packages/cw721", version = "0.10.0" }
 cw-storage-plus = { version = "0.10.2" }
 cosmwasm-std = { version = "1.0.0-beta2" }
 schemars = "0.8.6"

--- a/contracts/cw721-metadata-onchain/Cargo.toml
+++ b/contracts/cw721-metadata-onchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw721-metadata-onchain"
-version = "0.9.3"
+version = "0.10.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Example extending CW721 NFT to store metadata on chain"
@@ -25,8 +25,8 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw721 = { path = "../../packages/cw721", version = "0.9.3" }
-cw721-base = { path = "../cw721-base", version = "0.9.3", features = ["library"] }
+cw721 = { path = "../../packages/cw721", version = "0.10.0" }
+cw721-base = { path = "../cw721-base", version = "0.10.0", features = ["library"] }
 cosmwasm-std = { version = "1.0.0-beta2" }
 schemars = "0.8.6"
 serde = { version = "1.0.130", default-features = false, features = ["derive"] }

--- a/packages/cw721/Cargo.toml
+++ b/packages/cw721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw721"
-version = "0.9.3"
+version = "0.10.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Definition and types for the CosmWasm-721 NFT interface"


### PR DESCRIPTION
Tagging `v0.10.0` version as per @ethanfrey's suggestion.

Also added a top level `cargo wasm` command.