### PR TITLE
Approval query returns positive for Owner

### DIFF
--- a/contracts/cw721-base/src/contract_tests.rs
+++ b/contracts/cw721-base/src/contract_tests.rs
@@ -335,6 +335,26 @@ fn approving_revoking() {
         .execute(deps.as_mut(), mock_env(), minter, mint_msg)
         .unwrap();
 
+    // token owner shows in approval query
+    let res = contract
+        .approval(
+            deps.as_ref(),
+            mock_env(),
+            token_id.clone(),
+            String::from("demeter"),
+            false,
+        )
+        .unwrap();
+    assert_eq!(
+        res,
+        ApprovalResponse {
+            approval: Approval {
+                spender: String::from("demeter"),
+                expires: Expiration::Never {}
+            }
+        }
+    );
+
     // Give random transferring power
     let approve_msg = ExecuteMsg::Approve {
         spender: String::from("random"),

--- a/contracts/cw721-base/src/query.rs
+++ b/contracts/cw721-base/src/query.rs
@@ -90,6 +90,16 @@ where
         include_expired: bool,
     ) -> StdResult<ApprovalResponse> {
         let token = self.tokens.load(deps.storage, &token_id)?;
+
+        // token owner has absolute approval
+        if token.owner == spender {
+            let approval = cw721::Approval {
+                spender: token.owner.to_string(),
+                expires: Expiration::Never {},
+            };
+            return Ok(ApprovalResponse { approval });
+        }
+
         let filtered: Vec<_> = token
             .approvals
             .into_iter()


### PR DESCRIPTION
In an NFT project i had this case: 
```rust
        // check if sender has approval
        nft_contract
            .approval(
                &deps.querier,
                token.id.clone(),
                info.sender.clone().into_string(),
                None,
            )
            .map_err(|_e| ContractError::Unauthorized {})?;

```
Where I only want to check if sender has permission to operate nft.
If the sender is `owner`, this query returns unauthorized. In order to make this work, I need to run one more owner query which makes things complicated and expensive.