### PR TITLE
Upgrade rustc to fix the wasm-build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
 jobs:
   contract_cw721_base:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.56.1
     working_directory: ~/project/contracts/cw721-base
     steps:
       - checkout:
@@ -31,7 +31,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw721-base-rust:1.53.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw721-base-rust:1.56.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -53,12 +53,12 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw721-base-rust:1.53.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw721-base-rust:1.56.1-{{ checksum "~/project/Cargo.lock" }}
 
 
   contract_cw721_metadata_onchain:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.56.1
     working_directory: ~/project/contracts/cw721-metadata-onchain
     steps:
       - checkout:
@@ -68,7 +68,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw721-metadata-onchain-rust:1.53.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw721-metadata-onchain-rust:1.56.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -90,12 +90,12 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw721-metadata-onchain-rust:1.53.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw721-metadata-onchain-rust:1.56.1-{{ checksum "~/project/Cargo.lock" }}
 
 
   contract_cw721_fixed_price:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.56.1
     working_directory: ~/project/contracts/cw721-fixed-price
     steps:
       - checkout:
@@ -105,7 +105,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw721-fixed-price-rust:1.53.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw721-fixed-price-rust:1.56.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -127,12 +127,12 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw721-fixed-price-rust:1.53.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw721-fixed-price-rust:1.56.1-{{ checksum "~/project/Cargo.lock" }}
 
 
   package_cw721:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.56.1
     working_directory: ~/project/packages/cw721
     steps:
       - checkout:
@@ -142,7 +142,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-cw721:1.53.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-cw721:1.56.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -165,11 +165,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-cw721:1.53.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-cw721:1.56.1-{{ checksum "~/project/Cargo.lock" }}
 
   lint:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.56.1
     steps:
       - checkout
       - run:
@@ -177,7 +177,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-lint-rust:1.53.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-lint-rust:1.56.1-{{ checksum "Cargo.lock" }}
       - run:
           name: Add rustfmt component
           command: rustup component add rustfmt
@@ -196,7 +196,7 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-lint-rust:1.53.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-lint-rust:1.56.1-{{ checksum "Cargo.lock" }}
 
   # This runs one time on the top level to ensure all contracts compile properly into wasm.
   # We don't run the wasm build per contract build, and then reuse a lot of the same dependencies, so this speeds up CI time
@@ -204,7 +204,7 @@ jobs:
   # We also sanity-check the resultant wasm files.
   wasm-build:
     docker:
-      - image: rust:1.53.0
+      - image: rust:1.56.1
     steps:
       - checkout:
           path: ~/project
@@ -213,7 +213,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-wasm-rust:1.53.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-wasm-rust:1.56.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown
@@ -228,12 +228,12 @@ jobs:
       - run:
           name: Install check_contract
           # Uses --debug for compilation speed
-          command: cargo install --debug --version 1.0.0-beta2 --features iterator --example check_contract -- cosmwasm-vm
+          command: cargo install --debug --version 1.0.0-beta2 --features iterator --example check_contract --locked -- cosmwasm-vm
       - save_cache:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-wasm-rust:1.53.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-wasm-rust:1.56.1-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Check wasm contracts
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
 jobs:
   contract_cw721_base:
     docker:
-      - image: rust:1.56.1
+      - image: rust:1.55.0
     working_directory: ~/project/contracts/cw721-base
     steps:
       - checkout:
@@ -31,7 +31,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw721-base-rust:1.56.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw721-base-rust:1.55.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -53,12 +53,12 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw721-base-rust:1.56.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw721-base-rust:1.55.0-{{ checksum "~/project/Cargo.lock" }}
 
 
   contract_cw721_metadata_onchain:
     docker:
-      - image: rust:1.56.1
+      - image: rust:1.55.0
     working_directory: ~/project/contracts/cw721-metadata-onchain
     steps:
       - checkout:
@@ -68,7 +68,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw721-metadata-onchain-rust:1.56.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw721-metadata-onchain-rust:1.55.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -90,12 +90,12 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw721-metadata-onchain-rust:1.56.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw721-metadata-onchain-rust:1.55.0-{{ checksum "~/project/Cargo.lock" }}
 
 
   contract_cw721_fixed_price:
     docker:
-      - image: rust:1.56.1
+      - image: rust:1.55.0
     working_directory: ~/project/contracts/cw721-fixed-price
     steps:
       - checkout:
@@ -105,7 +105,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw721-fixed-price-rust:1.56.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw721-fixed-price-rust:1.55.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -127,12 +127,12 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw721-fixed-price-rust:1.56.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw721-fixed-price-rust:1.55.0-{{ checksum "~/project/Cargo.lock" }}
 
 
   package_cw721:
     docker:
-      - image: rust:1.56.1
+      - image: rust:1.55.0
     working_directory: ~/project/packages/cw721
     steps:
       - checkout:
@@ -142,7 +142,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-cw721:1.56.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-cw721:1.55.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -165,11 +165,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-cw721:1.56.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-cw721:1.55.0-{{ checksum "~/project/Cargo.lock" }}
 
   lint:
     docker:
-      - image: rust:1.56.1
+      - image: rust:1.55.0
     steps:
       - checkout
       - run:
@@ -177,7 +177,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-lint-rust:1.56.1-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-lint-rust:1.55.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add rustfmt component
           command: rustup component add rustfmt
@@ -196,7 +196,7 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-lint-rust:1.56.1-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-lint-rust:1.55.0-{{ checksum "Cargo.lock" }}
 
   # This runs one time on the top level to ensure all contracts compile properly into wasm.
   # We don't run the wasm build per contract build, and then reuse a lot of the same dependencies, so this speeds up CI time
@@ -204,7 +204,7 @@ jobs:
   # We also sanity-check the resultant wasm files.
   wasm-build:
     docker:
-      - image: rust:1.56.1
+      - image: rust:1.55.0
     steps:
       - checkout:
           path: ~/project
@@ -213,7 +213,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-wasm-rust:1.56.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-wasm-rust:1.55.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown
@@ -233,7 +233,7 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-wasm-rust:1.56.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-wasm-rust:1.55.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Check wasm contracts
           command: |

--- a/contracts/cw721-fixed-price/src/contract.rs
+++ b/contracts/cw721-fixed-price/src/contract.rs
@@ -161,7 +161,7 @@ pub fn execute_receive(
     });
 
     let callback = CosmosMsg::Wasm(WasmMsg::Execute {
-        contract_addr: config.cw721_address.clone().unwrap().to_string(),
+        contract_addr: config.cw20_address.to_string(),
         msg: to_binary(&mint_msg)?,
         funds: vec![],
     });
@@ -372,7 +372,7 @@ mod tests {
             res.messages[0],
             SubMsg {
                 msg: CosmosMsg::Wasm(WasmMsg::Execute {
-                    contract_addr: "nftcontract".to_string(),
+                    contract_addr: String::from(MOCK_CONTRACT_ADDR),
                     msg: to_binary(&mint_msg).unwrap(),
                     funds: vec![],
                 }),

--- a/contracts/cw721-fixed-price/src/contract.rs
+++ b/contracts/cw721-fixed-price/src/contract.rs
@@ -161,7 +161,7 @@ pub fn execute_receive(
     });
 
     let callback = CosmosMsg::Wasm(WasmMsg::Execute {
-        contract_addr: config.cw20_address.to_string(),
+        contract_addr: config.cw721_address.clone().unwrap().to_string(),
         msg: to_binary(&mint_msg)?,
         funds: vec![],
     });
@@ -372,7 +372,7 @@ mod tests {
             res.messages[0],
             SubMsg {
                 msg: CosmosMsg::Wasm(WasmMsg::Execute {
-                    contract_addr: String::from(MOCK_CONTRACT_ADDR),
+                    contract_addr: "nftcontract".to_string(),
                     msg: to_binary(&mint_msg).unwrap(),
                     funds: vec![],
                 }),


### PR DESCRIPTION
The `wasm-build` step failed due to `rkyv` package failed to build on old version rustc.