### PR TITLE
Update version numbers and upgrade to CosmWasm 1.0.0-beta5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-storage-plus"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c087ff98fb0475db4c2b5298a5fd12b2848d2854b39d1115d930ee6da24d1eed"
+dependencies = [
+ "cosmwasm-std",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "cw-utils"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,7 +218,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1d81d7c359d6c1fba3aa83dad7ec6f999e512571380ae62f81257c3db569743"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus",
+ "cw-storage-plus 0.11.1",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw2"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f8a6500c396e33f6a7b05d35a5124eb3e394cdb6ca901f7e88332870407896c"
+dependencies = [
+ "cosmwasm-std",
+ "cw-storage-plus 0.12.1",
  "schemars",
  "serde",
 ]
@@ -254,9 +277,9 @@ version = "0.11.1"
 dependencies = [
  "cosmwasm-schema 1.0.0-beta5",
  "cosmwasm-std",
- "cw-storage-plus",
- "cw-utils 0.11.1",
- "cw2",
+ "cw-storage-plus 0.12.1",
+ "cw-utils 0.12.1",
+ "cw2 0.12.1",
  "cw721",
  "schemars",
  "serde",
@@ -270,9 +293,9 @@ dependencies = [
  "cosmwasm-schema 1.0.0-beta5",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus",
+ "cw-storage-plus 0.11.1",
  "cw-utils 0.11.1",
- "cw2",
+ "cw2 0.11.1",
  "cw20",
  "cw721-base",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "cw721"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "cosmwasm-schema 1.0.0-beta5",
  "cosmwasm-std",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-base"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "cosmwasm-schema 1.0.0-beta5",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.0.0-beta4"
+version = "1.0.0-beta5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f903ebbabc0d4880dbc76148efb8be8fc29fa4bf294c440c3d70da1c8bcafff7"
+checksum = "8904127a5b9e325ef5d6b2b3f997dcd74943cd35097139b1a4d15b1b6bccae66"
 dependencies = [
  "digest",
  "ed25519-zebra",
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.0.0-beta4"
+version = "1.0.0-beta5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832bebef577ecb394603de8e2bf0de429b74aa364e17dec18e15ce37e71b0cae"
+checksum = "a14364ac4d9d085867929d0cf3e94b1d2100121ce02c33c72961406830002613"
 dependencies = [
  "syn",
 ]
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.0.0-beta4"
+version = "1.0.0-beta5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5de9749a4a933c34c59db83a77935a79cd705f93ae2b1cfbe40821f32751f75"
+checksum = "3b2941b87c42620d348e96ed05876bfda0dc1d5454a646d780d32f114c04921d"
 dependencies = [
  "schemars",
  "serde_json",
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.0.0-beta4"
+version = "1.0.0-beta5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6238c45840cc9de5a39f0f619e3a4f7c38c5d2c6ac9e3e4d72751ee045e6d7da"
+checksum = "e2ece12e5bbde434b93937d7b2107e6291f11d69ffa72398c50e8bab41d451d3"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -189,6 +189,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-utils"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3396c7aff5a0e3fb6dcc6cc89f56862c1d212b40d93ed725a6962955b1887ff"
+dependencies = [
+ "cosmwasm-std",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "cw2"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,7 +219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9671d7edef5608acaf5b2f1e473ee3f501eced2cd4f7392e2106c8cf02ba0720"
 dependencies = [
  "cosmwasm-std",
- "cw-utils",
+ "cw-utils 0.11.1",
  "schemars",
  "serde",
 ]
@@ -229,9 +241,9 @@ dependencies = [
 name = "cw721"
 version = "0.11.1"
 dependencies = [
- "cosmwasm-schema 1.0.0-beta4",
+ "cosmwasm-schema 1.0.0-beta5",
  "cosmwasm-std",
- "cw-utils",
+ "cw-utils 0.12.1",
  "schemars",
  "serde",
 ]
@@ -240,10 +252,10 @@ dependencies = [
 name = "cw721-base"
 version = "0.11.1"
 dependencies = [
- "cosmwasm-schema 1.0.0-beta4",
+ "cosmwasm-schema 1.0.0-beta5",
  "cosmwasm-std",
  "cw-storage-plus",
- "cw-utils",
+ "cw-utils 0.11.1",
  "cw2",
  "cw721",
  "schemars",
@@ -255,11 +267,11 @@ dependencies = [
 name = "cw721-fixed-price"
 version = "0.1.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-beta4",
+ "cosmwasm-schema 1.0.0-beta5",
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-storage-plus",
- "cw-utils",
+ "cw-utils 0.11.1",
  "cw2",
  "cw20",
  "cw721-base",
@@ -273,7 +285,7 @@ dependencies = [
 name = "cw721-metadata-onchain"
 version = "0.11.1"
 dependencies = [
- "cosmwasm-schema 1.0.0-beta4",
+ "cosmwasm-schema 1.0.0-beta5",
  "cosmwasm-std",
  "cw721",
  "cw721-base",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,16 +71,6 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be11bdd8a6e7c0f7d4d8b9fc00850b5a2a2ef5f059e4bda2841224ea78d13677"
-dependencies = [
- "schemars",
- "serde_json",
-]
-
-[[package]]
-name = "cosmwasm-schema"
 version = "1.0.0-beta5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b2941b87c42620d348e96ed05876bfda0dc1d5454a646d780d32f114c04921d"
@@ -107,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.0.0-beta4"
+version = "1.0.0-beta5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f472c0bfd584a4510702537d0b65c5331095e76099586a12f749fd69afda9c5e"
+checksum = "e7e4338d8e9934effa4594f139ce4e5f4b426796b70e2d53bb7e8605e9adf68c"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -167,17 +157,6 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7ee1963302b0ac2a9d42fe0faec826209c17452bfd36fbfd9d002a88929261"
-dependencies = [
- "cosmwasm-std",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw-storage-plus"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c087ff98fb0475db4c2b5298a5fd12b2848d2854b39d1115d930ee6da24d1eed"
@@ -185,18 +164,6 @@ dependencies = [
  "cosmwasm-std",
  "schemars",
  "serde",
-]
-
-[[package]]
-name = "cw-utils"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef842a1792e4285beff7b3b518705f760fa4111dc1e296e53f3e92d1ef7f6220"
-dependencies = [
- "cosmwasm-std",
- "schemars",
- "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -213,45 +180,33 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d81d7c359d6c1fba3aa83dad7ec6f999e512571380ae62f81257c3db569743"
-dependencies = [
- "cosmwasm-std",
- "cw-storage-plus 0.11.1",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw2"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f8a6500c396e33f6a7b05d35a5124eb3e394cdb6ca901f7e88332870407896c"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 0.12.1",
+ "cw-storage-plus",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw20"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9671d7edef5608acaf5b2f1e473ee3f501eced2cd4f7392e2106c8cf02ba0720"
+checksum = "413911037f6b0106ae37ca82352f9131939ccc995aade435df47a5baf2c815f2"
 dependencies = [
  "cosmwasm-std",
- "cw-utils 0.11.1",
+ "cw-utils",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw2981-royalties"
-version = "0.10.0"
+version = "0.12.0"
 dependencies = [
- "cosmwasm-schema 0.16.3",
+ "cosmwasm-schema",
  "cosmwasm-std",
  "cw721",
  "cw721-base",
@@ -261,12 +216,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw3"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "017b6263414c58081cea97626f4d8da2dc8f7267337bba0eb5770260d26251e0"
+dependencies = [
+ "cosmwasm-std",
+ "cw-utils",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "cw721"
 version = "0.12.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-beta5",
+ "cosmwasm-schema",
  "cosmwasm-std",
- "cw-utils 0.12.1",
+ "cw-utils",
  "schemars",
  "serde",
 ]
@@ -275,11 +242,11 @@ dependencies = [
 name = "cw721-base"
 version = "0.12.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-beta5",
+ "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.12.1",
- "cw-utils 0.12.1",
- "cw2 0.12.1",
+ "cw-storage-plus",
+ "cw-utils",
+ "cw2",
  "cw721",
  "schemars",
  "serde",
@@ -288,15 +255,16 @@ dependencies = [
 
 [[package]]
 name = "cw721-fixed-price"
-version = "0.1.0"
+version = "0.12.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-beta5",
+ "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus 0.11.1",
- "cw-utils 0.11.1",
- "cw2 0.11.1",
+ "cw-storage-plus",
+ "cw-utils",
+ "cw2",
  "cw20",
+ "cw3",
  "cw721-base",
  "prost",
  "schemars",
@@ -306,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "cw721-metadata-onchain"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
- "cosmwasm-schema 1.0.0-beta5",
+ "cosmwasm-schema",
  "cosmwasm-std",
  "cw721",
  "cw721-base",

--- a/contracts/cw2981-royalties/Cargo.toml
+++ b/contracts/cw2981-royalties/Cargo.toml
@@ -25,8 +25,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw721 = { path = "../../packages/cw721", version = "0.11" }
-cw721-base = { path = "../cw721-base", version = "0.11", features = ["library"] }
+cw721 = { path = "../../packages/cw721", version = "0.12.0" }
+cw721-base = { path = "../cw721-base", version = "0.12.0", features = [
+  "library",
+] }
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/contracts/cw2981-royalties/Cargo.toml
+++ b/contracts/cw2981-royalties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw2981-royalties"
-version = "0.10.0"
+version = "0.12.0"
 authors = ["Alex Lynham <alex@lynh.am>"]
 edition = "2018"
 description = "Basic implementation of royalties for cw721 NFTs with token level royalties"
@@ -29,10 +29,10 @@ cw721 = { path = "../../packages/cw721", version = "0.12.0" }
 cw721-base = { path = "../cw721-base", version = "0.12.0", features = [
   "library",
 ] }
-cosmwasm-std = { version = "1.0.0-beta" }
+cosmwasm-std = { version = "1.0.0-beta5" }
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.23" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "0.16.0" }
+cosmwasm-schema = { version = "1.0.0-beta5" }

--- a/contracts/cw721-base/Cargo.toml
+++ b/contracts/cw721-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw721-base"
-version = "0.11.1"
+version = "0.12.0"
 authors = [
   "Ethan Frey <ethanfrey@users.noreply.github.com>",
   "Orkun Külçe <orkun@deuslabs.fi>",
@@ -30,7 +30,7 @@ library = []
 [dependencies]
 cw-utils = "0.12.1"
 cw2 = "0.12.1"
-cw721 = { path = "../../packages/cw721", version = "0.11.1" }
+cw721 = { path = "../../packages/cw721", version = "0.12.0" }
 cw-storage-plus = "0.12.1"
 cosmwasm-std = { version = "1.0.0-beta5" }
 schemars = "0.8"

--- a/contracts/cw721-base/Cargo.toml
+++ b/contracts/cw721-base/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "cw721-base"
 version = "0.11.1"
-authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>", "Orkun Külçe <orkun@deuslabs.fi>"]
+authors = [
+  "Ethan Frey <ethanfrey@users.noreply.github.com>",
+  "Orkun Külçe <orkun@deuslabs.fi>",
+]
 edition = "2018"
 description = "Basic implementation cw721 NFTs"
 license = "Apache-2.0"
@@ -25,14 +28,14 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = { version = "0.11" }
-cw2 = { version = "0.11" }
-cw721 = { path = "../../packages/cw721", version = "0.11" }
-cw-storage-plus = { version = "0.11" }
-cosmwasm-std = { version = "1.0.0-beta" }
+cw-utils = "0.12.1"
+cw2 = "0.12.1"
+cw721 = { path = "../../packages/cw721", version = "0.11.1" }
+cw-storage-plus = "0.12.1"
+cosmwasm-std = { version = "1.0.0-beta5" }
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta" }
+cosmwasm-schema = { version = "1.0.0-beta5" }

--- a/contracts/cw721-base/src/query.rs
+++ b/contracts/cw721-base/src/query.rs
@@ -65,7 +65,7 @@ where
     ) -> StdResult<OperatorsResponse> {
         let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
         let start_addr = maybe_addr(deps.api, start_after)?;
-        let start = start_addr.map(|addr| Bound::exclusive(addr.as_ref()));
+        let start = start_addr.as_ref().map(Bound::exclusive);
 
         let owner_addr = deps.api.addr_validate(&owner)?;
         let res: StdResult<Vec<_>> = self
@@ -150,7 +150,7 @@ where
         limit: Option<u32>,
     ) -> StdResult<TokensResponse> {
         let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-        let start = start_after.map(Bound::exclusive);
+        let start = start_after.map(|s| Bound::ExclusiveRaw(s.into()));
 
         let owner_addr = deps.api.addr_validate(&owner)?;
         let tokens: Vec<String> = self
@@ -173,7 +173,7 @@ where
         limit: Option<u32>,
     ) -> StdResult<TokensResponse> {
         let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-        let start = start_after.map(Bound::exclusive);
+        let start = start_after.map(|s| Bound::ExclusiveRaw(s.into()));
 
         let tokens: StdResult<Vec<String>> = self
             .tokens

--- a/contracts/cw721-fixed-price/Cargo.toml
+++ b/contracts/cw721-fixed-price/Cargo.toml
@@ -45,11 +45,13 @@ cosmwasm-storage = { version = "1.0.0-beta" }
 cw-storage-plus = "0.11.1"
 cw2 = "0.11.1"
 schemars = "0.8.3"
-cw721-base = { path = "../cw721-base", version = "0.11.1", features = [ "library"] }
+cw721-base = { path = "../cw721-base", version = "0.12.0", features = [
+  "library",
+] }
 cw20 = "0.11.1"
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.26" }
-cw-utils = { version= "0.11.1" }
+cw-utils = { version = "0.11.1" }
 prost = "0.9.0"
 
 [dev-dependencies]

--- a/contracts/cw721-fixed-price/Cargo.toml
+++ b/contracts/cw721-fixed-price/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw721-fixed-price"
-version = "0.1.0"
+version = "0.12.0"
 authors = ["Vernon Johnson <vtj2105@columbia.edu>"]
 edition = "2018"
 
@@ -40,19 +40,20 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0-beta" }
-cosmwasm-storage = { version = "1.0.0-beta" }
-cw-storage-plus = "0.11.1"
-cw2 = "0.11.1"
+cosmwasm-std = { version = "1.0.0-beta5" }
+cosmwasm-storage = { version = "1.0.0-beta5" }
+cw-storage-plus = "0.12.1"
+cw2 = "0.12.1"
 schemars = "0.8.3"
 cw721-base = { path = "../cw721-base", version = "0.12.0", features = [
   "library",
 ] }
-cw20 = "0.11.1"
+cw20 = "0.12.1"
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.26" }
-cw-utils = { version = "0.11.1" }
+cw-utils = "0.12.1"
 prost = "0.9.0"
+cw3 = "0.12.1"
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta" }
+cosmwasm-schema = { version = "1.0.0-beta5" }

--- a/contracts/cw721-metadata-onchain/Cargo.toml
+++ b/contracts/cw721-metadata-onchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw721-metadata-onchain"
-version = "0.11.1"
+version = "0.12.0"
 authors = [
   "Ethan Frey <ethanfrey@users.noreply.github.com>",
   "Orkun Külçe <orkun@deuslabs.fi>",
@@ -32,10 +32,10 @@ cw721 = { path = "../../packages/cw721", version = "0.12.0" }
 cw721-base = { path = "../cw721-base", version = "0.12.0", features = [
   "library",
 ] }
-cosmwasm-std = { version = "1.0.0-beta" }
+cosmwasm-std = { version = "1.0.0-beta5" }
 schemars = "0.8"
 serde = { version = "1.0.130", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.30" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta" }
+cosmwasm-schema = { version = "1.0.0-beta5" }

--- a/contracts/cw721-metadata-onchain/Cargo.toml
+++ b/contracts/cw721-metadata-onchain/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "cw721-metadata-onchain"
 version = "0.11.1"
-authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>", "Orkun Külçe <orkun@deuslabs.fi>"]
+authors = [
+  "Ethan Frey <ethanfrey@users.noreply.github.com>",
+  "Orkun Külçe <orkun@deuslabs.fi>",
+]
 edition = "2018"
 description = "Example extending CW721 NFT to store metadata on chain"
 license = "Apache-2.0"
@@ -25,8 +28,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw721 = { path = "../../packages/cw721", version = "0.11" }
-cw721-base = { path = "../cw721-base", version = "0.11", features = ["library"] }
+cw721 = { path = "../../packages/cw721", version = "0.12.0" }
+cw721-base = { path = "../cw721-base", version = "0.12.0", features = [
+  "library",
+] }
 cosmwasm-std = { version = "1.0.0-beta" }
 schemars = "0.8"
 serde = { version = "1.0.130", default-features = false, features = ["derive"] }

--- a/packages/cw721/Cargo.toml
+++ b/packages/cw721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw721"
-version = "0.11.1"
+version = "0.12.0"
 authors = [
     "Ethan Frey <ethanfrey@users.noreply.github.com>",
     "Orkun Külçe <orkun@deuslabs.fi>",

--- a/packages/cw721/Cargo.toml
+++ b/packages/cw721/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "cw721"
 version = "0.11.1"
-authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>", "Orkun Külçe <orkun@deuslabs.fi>"]
+authors = [
+    "Ethan Frey <ethanfrey@users.noreply.github.com>",
+    "Orkun Külçe <orkun@deuslabs.fi>",
+]
 edition = "2018"
 description = "Definition and types for the CosmWasm-721 NFT interface"
 license = "Apache-2.0"
@@ -10,10 +13,10 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw-utils = { version = "0.11" }
-cosmwasm-std = { version = "1.0.0-beta" }
+cw-utils = "0.12.1"
+cosmwasm-std = { version = "1.0.0-beta5" }
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta" }
+cosmwasm-schema = { version = "1.0.0-beta5" }


### PR DESCRIPTION
* Upgrades cw721 and cw721-base to v0.12.0
* Updates CosmWasm to v1.0.0-beta5 (requires Bounds updates) for cw721 and cw721-base