### PR TITLE
add missing owner attribute to mint event

### DIFF
--- a/contracts/cw721-base/src/execute.rs
+++ b/contracts/cw721-base/src/execute.rs
@@ -110,6 +110,7 @@ where
         Ok(Response::new()
             .add_attribute("action", "mint")
             .add_attribute("minter", info.sender)
+            .add_attribute("owner", msg.owner)
             .add_attribute("token_id", msg.token_id))
     }
 }


### PR DESCRIPTION
owner attribute was not added to the event.