### PR TITLE
Fix TokenIndexes MultiIndex

### DIFF
--- a/contracts/cw721-base/src/query.rs
+++ b/contracts/cw721-base/src/query.rs
@@ -160,7 +160,6 @@ where
             .prefix(owner_addr)
             .keys(deps.storage, start, None, Order::Ascending)
             .take(limit)
-            .map(|x| x.map(|addr| addr.to_string()))
             .collect::<StdResult<Vec<_>>>()?;
 
         Ok(TokensResponse { tokens })

--- a/contracts/cw721-base/src/state.rs
+++ b/contracts/cw721-base/src/state.rs
@@ -122,7 +122,7 @@ pub struct TokenIndexes<'a, T>
 where
     T: Serialize + DeserializeOwned + Clone,
 {
-    pub owner: MultiIndex<'a, Addr, TokenInfo<T>, Addr>,
+    pub owner: MultiIndex<'a, Addr, TokenInfo<T>, String>,
 }
 
 impl<'a, T> IndexList<TokenInfo<T>> for TokenIndexes<'a, T>


### PR DESCRIPTION
The Multiindex for TokenIndexes works by accident and not by design

The key on a token index should be a String and not an Addr
The conversion of Addr to String is why existing setup does not fail any unit tests

An example usage below:  
If we have this data
```
"1": {owner: <addr1>, name: name1} 
"2": {owner: <addr1>, name: name2} 
"3": {owner: <addr2>, name: name3} 
```
The type structure being 
```
Map {
String: TokenInfo {
       "owner": <Addr>
       "data": <somedata>
    }, 
String: TokenInfo {
        "owner": <Addr>
        "data": <somedata>
    }, 
    ...
 }
 ```
To uniquely identify each entry, I need to differentiate by the key, which in this case is a String
The purpose of the index, is to get token ids by providing an owner address. So, 
input: `<addr1>` 
output: `["1", "2"]`

so the index is by owner <addr1> and then I get back the keys associated with it ["1", "2"]

Note that an owner (addr) can have multiple token ids (string)
So index by owner, is similar to tokens "group by" owner