### PR TITLE
Square cw721 spec with cw721-base

### DIFF
--- a/contracts/cw721-base/src/msg.rs
+++ b/contracts/cw721-base/src/msg.rs
@@ -81,7 +81,6 @@ pub enum QueryMsg {
         /// unset or false will filter out expired approvals, you must set to true to see them
         include_expired: Option<bool>,
     },
-
     /// Return operator that can access all of the owner's tokens.
     /// Return type: `ApprovalResponse`
     Approval {
@@ -89,14 +88,12 @@ pub enum QueryMsg {
         spender: String,
         include_expired: Option<bool>,
     },
-
     /// Return approvals that a token has
     /// Return type: `ApprovalsResponse`
     Approvals {
         token_id: String,
         include_expired: Option<bool>,
     },
-
     /// List all operators that can access all of the owner's tokens
     /// Return type: `OperatorsResponse`
     AllOperators {

--- a/packages/cw721/README.md
+++ b/packages/cw721/README.md
@@ -53,18 +53,26 @@ to the given `operator`.
 
 ### Queries
 
-`OwnerOf{token_id}` - Returns the owner of the given token,
-as well as anyone with approval on this particular token.
-If the token is unknown, returns an error. Return type is
-`OwnerResponse{owner}`.
+`OwnerOf{token_id, include_expired}` - Returns the owner of the given token,
+as well as anyone with approval on this particular token. If the token is
+unknown, returns an error. Return type is `OwnerOfResponse`. If
+`include_expired` is set, show expired owners in the results, otherwise, ignore
+them.
 
-`Approved{owner, operator}` - Return operator that can access all of the
-owner's tokens. Return type is `ApprovedResponse`.
+`Approval{token_id, spender, include_expired}` - Return operator that can access
+all of the owner's tokens. Return type is `ApprovalResponse`. If
+`include_expired` is set, show expired owners in the results, otherwise, ignore
+them.
 
-`ApprovedForAll{owner, include_expired}` - List all operators that can
-access all of the owner's tokens. Return type is `ApprovedForAllResponse`.
-If `include_expired` is set, show expired owners in the results, otherwise,
-ignore them.
+`Approvals{token_id, include_expired}` - Return approvals that a token has.
+Return type is `ApprovalsResponse`. If `include_expired` is set, show expired
+owners in the results, otherwise, ignore them.
+
+`AllOperators{owner, include_expired, start_after, limit}` - List all
+operators that can access all of the owner's tokens. Return type is
+`OperatorsResponse`. If `include_expired` is set, show expired owners in the
+results, otherwise, ignore them. If `start_after` is set, then it returns the
+first `limit` tokens after the given one.
 
 `NumTokens{}` - Total number of tokens issued
 

--- a/packages/cw721/README.md
+++ b/packages/cw721/README.md
@@ -59,20 +59,20 @@ unknown, returns an error. Return type is `OwnerOfResponse`. If
 `include_expired` is set, show expired owners in the results, otherwise, ignore
 them.
 
-`Approval{token_id, spender, include_expired}` - Return operator that can access
-all of the owner's tokens. Return type is `ApprovalResponse`. If
+`Approval{token_id, spender, include_expired}` - Return an approval of `spender`
+about the given `token_id`. Return type is `ApprovalResponse`. If
 `include_expired` is set, show expired owners in the results, otherwise, ignore
 them.
 
-`Approvals{token_id, include_expired}` - Return approvals that a token has.
-Return type is `ApprovalsResponse`. If `include_expired` is set, show expired
-owners in the results, otherwise, ignore them.
+`Approvals{token_id, include_expired}` - Return all approvals that owner given
+access to. Return type is `ApprovalsResponse`. If `include_expired` is set, show
+expired owners in the results, otherwise, ignore them.
 
 `AllOperators{owner, include_expired, start_after, limit}` - List all
 operators that can access all of the owner's tokens. Return type is
 `OperatorsResponse`. If `include_expired` is set, show expired owners in the
 results, otherwise, ignore them. If `start_after` is set, then it returns the
-first `limit` tokens after the given one.
+first `limit` operators *after* the given one.
 
 `NumTokens{}` - Total number of tokens issued
 

--- a/packages/cw721/README.md
+++ b/packages/cw721/README.md
@@ -58,6 +58,9 @@ as well as anyone with approval on this particular token.
 If the token is unknown, returns an error. Return type is
 `OwnerResponse{owner}`.
 
+`Approved{owner, operator}` - Return operator that can access all of the
+owner's tokens. Return type is `ApprovedResponse`.
+
 `ApprovedForAll{owner, include_expired}` - List all operators that can
 access all of the owner's tokens. Return type is `ApprovedForAllResponse`.
 If `include_expired` is set, show expired owners in the results, otherwise,

--- a/packages/cw721/schema/cw721_query_msg.json
+++ b/packages/cw721/schema/cw721_query_msg.json
@@ -31,23 +31,29 @@
       "additionalProperties": false
     },
     {
-      "description": "Return operator that can access all of the owner's tokens. Return type: `ApprovedResponse`",
+      "description": "Return operator that can access all of the owner's tokens. Return type: `ApprovalResponse`",
       "type": "object",
       "required": [
-        "approved"
+        "approval"
       ],
       "properties": {
-        "approved": {
+        "approval": {
           "type": "object",
           "required": [
-            "operator",
-            "owner"
+            "spender",
+            "token_id"
           ],
           "properties": {
-            "operator": {
+            "include_expired": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "spender": {
               "type": "string"
             },
-            "owner": {
+            "token_id": {
               "type": "string"
             }
           }
@@ -56,20 +62,47 @@
       "additionalProperties": false
     },
     {
-      "description": "List all operators that can access all of the owner's tokens. Return type: `ApprovedForAllResponse`",
+      "description": "Return approvals that a token has Return type: `ApprovalsResponse`",
       "type": "object",
       "required": [
-        "approved_for_all"
+        "approvals"
       ],
       "properties": {
-        "approved_for_all": {
+        "approvals": {
+          "type": "object",
+          "required": [
+            "token_id"
+          ],
+          "properties": {
+            "include_expired": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "token_id": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "List all operators that can access all of the owner's tokens Return type: `OperatorsResponse`",
+      "type": "object",
+      "required": [
+        "all_operators"
+      ],
+      "properties": {
+        "all_operators": {
           "type": "object",
           "required": [
             "owner"
           ],
           "properties": {
             "include_expired": {
-              "description": "unset or false will filter out expired approvals, you must set to true to see them",
+              "description": "unset or false will filter out expired items, you must set to true to see them",
               "type": [
                 "boolean",
                 "null"

--- a/packages/cw721/src/query.rs
+++ b/packages/cw721/src/query.rs
@@ -13,16 +13,24 @@ pub enum Cw721QueryMsg {
         /// unset or false will filter out expired approvals, you must set to true to see them
         include_expired: Option<bool>,
     },
-
     /// Return operator that can access all of the owner's tokens.
-    /// Return type: `ApprovedResponse`
-    Approved { owner: String, operator: String },
-
-    /// List all operators that can access all of the owner's tokens.
-    /// Return type: `ApprovedForAllResponse`
-    ApprovedForAll {
+    /// Return type: `ApprovalResponse`
+    Approval {
+        token_id: String,
+        spender: String,
+        include_expired: Option<bool>,
+    },
+    /// Return approvals that a token has
+    /// Return type: `ApprovalsResponse`
+    Approvals {
+        token_id: String,
+        include_expired: Option<bool>,
+    },
+    /// List all operators that can access all of the owner's tokens
+    /// Return type: `OperatorsResponse`
+    AllOperators {
         owner: String,
-        /// unset or false will filter out expired approvals, you must set to true to see them
+        /// unset or false will filter out expired items, you must set to true to see them
         include_expired: Option<bool>,
         start_after: Option<String>,
         limit: Option<u32>,
@@ -36,7 +44,9 @@ pub enum Cw721QueryMsg {
     /// With MetaData Extension.
     /// Returns metadata about one particular token, based on *ERC721 Metadata JSON Schema*
     /// but directly from the contract: `NftInfoResponse`
-    NftInfo { token_id: String },
+    NftInfo {
+        token_id: String,
+    },
     /// With MetaData Extension.
     /// Returns the result of both `NftInfo` and `OwnerOf` as one query as an optimization
     /// for clients: `AllNftInfo`

--- a/packages/cw721/src/query.rs
+++ b/packages/cw721/src/query.rs
@@ -44,9 +44,7 @@ pub enum Cw721QueryMsg {
     /// With MetaData Extension.
     /// Returns metadata about one particular token, based on *ERC721 Metadata JSON Schema*
     /// but directly from the contract: `NftInfoResponse`
-    NftInfo {
-        token_id: String,
-    },
+    NftInfo { token_id: String },
     /// With MetaData Extension.
     /// Returns the result of both `NftInfo` and `OwnerOf` as one query as an optimization
     /// for clients: `AllNftInfo`


### PR DESCRIPTION
Related to: https://github.com/CosmWasm/cw-nfts/issues/62

* Fix `query.rs` to bring cw721 spec to match cw721-base.
* Group `QueryMsg` in cw721-base to abide by Base, Metadata, and Enumerable described at cw721 spec.
* Update `README.md`.