### PR TITLE
Include execute, query, and instantiate methods in library build.

### DIFF
--- a/contracts/cw721-base/src/lib.rs
+++ b/contracts/cw721-base/src/lib.rs
@@ -14,15 +14,15 @@ use cosmwasm_std::Empty;
 // This is a simple type to let us handle empty extensions
 pub type Extension = Option<Empty>;
 
-#[cfg(not(feature = "library"))]
 pub mod entry {
     use super::*;
 
+    #[cfg(not(feature = "library"))]
     use cosmwasm_std::entry_point;
     use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
 
     // This makes a conscious choice on the various generics used by the contract
-    #[entry_point]
+    #[cfg_attr(not(feature = "library"), entry_point)]
     pub fn instantiate(
         deps: DepsMut,
         env: Env,
@@ -33,7 +33,7 @@ pub mod entry {
         tract.instantiate(deps, env, info, msg)
     }
 
-    #[entry_point]
+    #[cfg_attr(not(feature = "library"), entry_point)]
     pub fn execute(
         deps: DepsMut,
         env: Env,
@@ -44,7 +44,7 @@ pub mod entry {
         tract.execute(deps, env, info, msg)
     }
 
-    #[entry_point]
+    #[cfg_attr(not(feature = "library"), entry_point)]
     pub fn query(deps: Deps, env: Env, msg: QueryMsg<Empty>) -> StdResult<Binary> {
         let tract = Cw721Contract::<Extension, Empty, Empty, Empty>::default();
         tract.query(deps, env, msg)


### PR DESCRIPTION
Cargo uses [feature unification](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification) during dependency compilation. During feature unification, cargo determines the union (set theory edition) of all the features set for a given crate and compiles _one_ version of that library with those features enabled. The top level crate or workspace then is linked against this unified library.

From the docs:

> A consequence of this is that features should be additive. That is, enabling a feature should not disable functionality.

At the moment, enabling the `library` feature removes the `entry` module from the contract. This violates the assumption cargo makes about features and results in a position where it is impossible to both use `cw721_base` in `[dependencies]` and use it in multitest.

Reason being that when cargo sees something like:

```toml
[dependencies]
cw721-base = { version = "0.13.4", features = ["library"] }

[dev-dependencies]
cw721-base = "0.13.4" 
```

It does feature unification causing the test build to have the `library` feature thus preventing us from using the provided execute methods.