### PR TITLE
Bump cosmwasm to v1.1, tidy up dependencies, update schema, update CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ jobs:
       - run:
           name: Install check_contract
           # Uses --debug for compilation speed
-          command: cargo install --debug --version 1.0.0-beta8 --features iterator --example check_contract --locked -- cosmwasm-vm
+          command: cargo install --debug --version 1.1.0 --features iterator --example check_contract --locked -- cosmwasm-vm
       - save_cache:
           paths:
             - /usr/local/cargo/registry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
 jobs:
   contract_cw721_base:
     docker:
-      - image: rust:1.63.0
+      - image: rust:1.60.0
     working_directory: ~/project/contracts/cw721-base
     steps:
       - checkout:
@@ -31,7 +31,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw721-base-rust:1.63.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw721-base-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -53,11 +53,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw721-base-rust:1.63.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw721-base-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw721_metadata_onchain:
     docker:
-      - image: rust:1.63.0
+      - image: rust:1.60.0
     working_directory: ~/project/contracts/cw721-metadata-onchain
     steps:
       - checkout:
@@ -67,7 +67,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw721-metadata-onchain-rust:1.63.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw721-metadata-onchain-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -89,11 +89,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw721-metadata-onchain-rust:1.63.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw721-metadata-onchain-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw721_fixed_price:
     docker:
-      - image: rust:1.63.0
+      - image: rust:1.60.0
     working_directory: ~/project/contracts/cw721-fixed-price
     steps:
       - checkout:
@@ -103,7 +103,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw721-fixed-price-rust:1.63.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw721-fixed-price-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -125,11 +125,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw721-fixed-price-rust:1.63.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw721-fixed-price-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_cw721:
     docker:
-      - image: rust:1.63.0
+      - image: rust:1.60.0
     working_directory: ~/project/packages/cw721
     steps:
       - checkout:
@@ -139,7 +139,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-cw721:1.63.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-cw721:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -162,11 +162,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-cw721:1.63.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-cw721:1.60.0-{{ checksum "~/project/Cargo.lock" }}
 
   lint:
     docker:
-      - image: rust:1.63.0
+      - image: rust:1.60.0
     steps:
       - checkout
       - run:
@@ -174,7 +174,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-lint-rust:1.63.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-lint-rust:1.60.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add rustfmt component
           command: rustup component add rustfmt
@@ -193,7 +193,7 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-lint-rust:1.63.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-lint-rust:1.60.0-{{ checksum "Cargo.lock" }}
 
   # This runs one time on the top level to ensure all contracts compile properly into wasm.
   # We don't run the wasm build per contract build, and then reuse a lot of the same dependencies, so this speeds up CI time
@@ -201,7 +201,7 @@ jobs:
   # We also sanity-check the resultant wasm files.
   wasm-build:
     docker:
-      - image: rust:1.63.0
+      - image: rust:1.60.0
     steps:
       - checkout:
           path: ~/project
@@ -210,7 +210,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-wasm-rust:1.63.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-wasm-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown
@@ -230,7 +230,7 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-wasm-rust:1.63.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-wasm-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Check wasm contracts
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
 jobs:
   contract_cw721_base:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.63.0
     working_directory: ~/project/contracts/cw721-base
     steps:
       - checkout:
@@ -31,7 +31,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw721-base-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw721-base-rust:1.63.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -53,11 +53,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw721-base-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw721-base-rust:1.63.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw721_metadata_onchain:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.63.0
     working_directory: ~/project/contracts/cw721-metadata-onchain
     steps:
       - checkout:
@@ -67,7 +67,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw721-metadata-onchain-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw721-metadata-onchain-rust:1.63.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -89,11 +89,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw721-metadata-onchain-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw721-metadata-onchain-rust:1.63.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw721_fixed_price:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.63.0
     working_directory: ~/project/contracts/cw721-fixed-price
     steps:
       - checkout:
@@ -103,7 +103,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw721-fixed-price-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw721-fixed-price-rust:1.63.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -125,11 +125,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw721-fixed-price-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw721-fixed-price-rust:1.63.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_cw721:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.63.0
     working_directory: ~/project/packages/cw721
     steps:
       - checkout:
@@ -139,7 +139,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-cw721:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-cw721:1.63.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -162,11 +162,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-cw721:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-cw721:1.63.0-{{ checksum "~/project/Cargo.lock" }}
 
   lint:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.63.0
     steps:
       - checkout
       - run:
@@ -174,7 +174,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-lint-rust:1.58.1-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-lint-rust:1.63.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add rustfmt component
           command: rustup component add rustfmt
@@ -193,7 +193,7 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-lint-rust:1.58.1-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-lint-rust:1.63.0-{{ checksum "Cargo.lock" }}
 
   # This runs one time on the top level to ensure all contracts compile properly into wasm.
   # We don't run the wasm build per contract build, and then reuse a lot of the same dependencies, so this speeds up CI time
@@ -201,7 +201,7 @@ jobs:
   # We also sanity-check the resultant wasm files.
   wasm-build:
     docker:
-      - image: rust:1.58.1
+      - image: rust:1.63.0
     steps:
       - checkout:
           path: ~/project
@@ -210,7 +210,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-wasm-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-wasm-rust:1.63.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown
@@ -230,7 +230,7 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-wasm-rust:1.58.1-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-wasm-rust:1.63.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Check wasm contracts
           command: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
 
 [[package]]
 name = "base16ct"
@@ -22,9 +22,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64ct"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdca834647821e0b13d9539a8634eb62d3501b6b6c2cec1722786ee6671b851"
+checksum = "ea2b2456fd614d856680dcd9fcc660a51a820fa09daef2e49772b56a193c8474"
 
 [[package]]
 name = "block-buffer"
@@ -52,9 +52,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b3de4a0c5e67e16066a0715723abd91edc2f9001d09c46e1dca929351e130e"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cfg-if"
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d07a982d1fb29db01e5a59b1918e03da4df7297eaeee7686ac45542fd4e59c8"
+checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 
 [[package]]
 name = "ecdsa"
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "elliptic-curve"
@@ -418,9 +418,9 @@ checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -485,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "k256"
@@ -503,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "opaque-debug"
@@ -525,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
@@ -557,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "schemars"
@@ -645,9 +645,9 @@ checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "serde"
-version = "1.0.140"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
@@ -663,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.140"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa",
  "ryu",
@@ -752,9 +752,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -763,18 +763,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -801,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,17 +64,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb0afef2325df81aadbf9be1233f522ed8f6e91df870c764bc44cca2b1415bd"
+checksum = "16c50d753d44148c7ff3279ac44b87b5b91e790f4c70db0e3900df211310a2bf"
 dependencies = [
- "digest",
+ "digest 0.10.3",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.3",
@@ -74,48 +83,53 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b36e527620a2a3e00e46b6e731ab6c9b68d11069c986f7d7be8eba79ef081a4"
+checksum = "9053ebe2ad85831e9f9e2124fa2b22807528a78b25cc447483ce2a4aadfba394"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772e80bbad231a47a2068812b723a1ff81dd4a0d56c9391ac748177bea3a61da"
+checksum = "8c742fc698a88cf02ea304cc2b5bc18ef975c5bb9eff93c3e44d2cd565e1d458"
 dependencies = [
+ "cosmwasm-schema-derive",
  "schemars",
+ "serde",
  "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "cosmwasm-schema-derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a7c4c07be11add09dd3af3064c4f4cbc2dc99c6859129bdaf820131730e996"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875994993c2082a6fcd406937bf0fca21c349e4a624f3810253a14fa83a3a195"
+checksum = "eb8da0ae28693d892af2944319b48adc23c42725dc0fe7271b8baa38c10865da"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
  "cosmwasm-derive",
+ "derivative",
  "forward_ref",
  "schemars",
  "serde",
  "serde-json-wasm",
  "thiserror",
  "uint",
-]
-
-[[package]]
-name = "cosmwasm-storage"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d18403b07304d15d304dad11040d45bbcaf78d603b4be3fb5e2685c16f9229b5"
-dependencies = [
- "cosmwasm-std",
- "serde",
 ]
 
 [[package]]
@@ -135,9 +149,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.3.2"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+checksum = "9f2b443d17d49dad5ef0ede301c3179cc923b8822f3393b4d2c28c269dd4a122"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -146,23 +160,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.1"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "subtle",
+ "typenum",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
@@ -170,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648b1507290bbc03a8d88463d7cd9b04b1fa0155e5eef366c4fa052b9caaac7a"
+checksum = "1c8b264257c4f44c49b7ce09377af63aa040768ecd3fd7bdd2d48a09323a1e90"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -181,21 +195,23 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbaecb78c8e8abfd6b4258c7f4fbeb5c49a5e45ee4d910d3240ee8e1d714e1b"
+checksum = "414b91f3d7a619bb26c835119d7095804596a1382ddc1d184c33c1d2c17f6c5e"
 dependencies = [
  "cosmwasm-std",
+ "cw2",
  "schemars",
+ "semver",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "cw2"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cf4639517490dd36b333bbd6c4fbd92e325fd0acf4683b41753bc5eb63bfc1"
+checksum = "aa74c324af8e3506fd8d50759a265bead3f87402e413c840042af5d2808463d6"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -205,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "cw20"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb782b8f110819a4eb5dbbcfed25ffba49ec16bbe32b4ad8da50a5ce68fec05"
+checksum = "4f446f59c519fbac5ab8b9f6c7f8dcaa05ee761703971406b28221ea778bb737"
 dependencies = [
  "cosmwasm-std",
  "cw-utils",
@@ -217,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "cw2981-royalties"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -226,24 +242,11 @@ dependencies = [
  "cw721-base",
  "schemars",
  "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw3"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe19462a7f644ba60c19d3443cb90d00c50d9b6b3b0a3a7fca93df8261af979b"
-dependencies = [
- "cosmwasm-std",
- "cw-utils",
- "schemars",
- "serde",
 ]
 
 [[package]]
 name = "cw721"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -254,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-base"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -269,16 +272,14 @@ dependencies = [
 
 [[package]]
 name = "cw721-fixed-price"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-storage-plus",
  "cw-utils",
  "cw2",
  "cw20",
- "cw3",
  "cw721-base",
  "prost",
  "schemars",
@@ -288,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-metadata-onchain"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -297,16 +298,27 @@ dependencies = [
  "cw721-base",
  "schemars",
  "serde",
- "thiserror",
 ]
 
 [[package]]
 name = "der"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
 dependencies = [
  "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -319,6 +331,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.3",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,9 +349,9 @@ checksum = "9d07a982d1fb29db01e5a59b1918e03da4df7297eaeee7686ac45542fd4e59c8"
 
 [[package]]
 name = "ecdsa"
-version = "0.13.4"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
+checksum = "fd6f2ba6c133e1d5390e2351b10b17aa43a41209c821c98efc4ec493d16a5a91"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -346,7 +369,7 @@ dependencies = [
  "hex",
  "rand_core 0.6.3",
  "serde",
- "sha2",
+ "sha2 0.9.9",
  "thiserror",
  "zeroize",
 ]
@@ -359,16 +382,18 @@ checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.12"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
+ "digest 0.10.3",
  "ff",
  "generic-array",
  "group",
+ "pkcs8",
  "rand_core 0.6.3",
  "sec1",
  "subtle",
@@ -377,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
+checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
@@ -425,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
+checksum = "7391856def869c1c81063a03457c676fbcd419709c3dfb33d8d319de484b154d"
 dependencies = [
  "ff",
  "rand_core 0.6.3",
@@ -442,12 +467,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "crypto-mac",
- "digest",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -467,15 +491,14 @@ checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "k256"
-version = "0.10.4"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c3a5e0a0b8450278feda242592512e09f61c72e018b8cd5c859482802daf2d"
+checksum = "6db2573d3fd3e4cc741affc9b5ce1a8ce36cf29f09f80f36da4309d0ae6d7854"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sec1",
- "sha2",
+ "sha2 0.10.5",
 ]
 
 [[package]]
@@ -492,13 +515,12 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pkcs8"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der",
  "spki",
- "zeroize",
 ]
 
 [[package]]
@@ -562,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+checksum = "88c86280f057430a52f4861551b092a01b419b8eacefc7c995eacb9dc132fe32"
 dependencies = [
  "crypto-bigint",
  "hmac",
@@ -603,16 +625,23 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
+ "base16ct",
  "der",
  "generic-array",
  "pkcs8",
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "serde"
@@ -671,28 +700,39 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
 [[package]]
-name = "signature"
-version = "1.4.0"
+name = "sha2"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
+checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
 dependencies = [
- "digest",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
+]
+
+[[package]]
+name = "signature"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e90531723b08e4d6d71b791108faf51f03e1b4a7784f96b2b87f852ebc247228"
+dependencies = [
+ "digest 0.10.3",
  "rand_core 0.6.3",
 ]
 
 [[package]]
 name = "spki"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
  "der",
@@ -785,6 +825,6 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"

--- a/contracts/cw2981-royalties/Cargo.toml
+++ b/contracts/cw2981-royalties/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw2981-royalties"
-version = "0.13.4"
+version = "0.14.0"
 authors = ["Alex Lynham <alex@lynh.am>"]
 edition = "2018"
 description = "Basic implementation of royalties for cw721 NFTs with token level royalties"
@@ -25,15 +25,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw2 = "0.13.4"
-cw721 = { path = "../../packages/cw721", version = "0.13.4" }
-cw721-base = { path = "../cw721-base", version = "0.13.4", features = [
-  "library",
-] }
-cosmwasm-std = { version = "1.0.0" }
-schemars = "0.8.10"
-serde = { version = "1.0.140", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0.31" }
-
-[dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
+cosmwasm-schema = "1.1"
+cosmwasm-std = "1.1"
+cw2 = "0.14"
+cw721 = { path = "../../packages/cw721" }
+cw721-base = { path = "../cw721-base", features = ["library"] }
+schemars = "0.8"
+serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/contracts/cw2981-royalties/Cargo.toml
+++ b/contracts/cw2981-royalties/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cw2981-royalties"
 version = "0.14.0"
 authors = ["Alex Lynham <alex@lynh.am>"]
-edition = "2018"
+edition = "2021"
 description = "Basic implementation of royalties for cw721 NFTs with token level royalties"
 license = "Apache-2.0"
 repository = "https://github.com/CosmWasm/cw-nfts"

--- a/contracts/cw2981-royalties/Cargo.toml
+++ b/contracts/cw2981-royalties/Cargo.toml
@@ -25,10 +25,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-schema = "1.1"
-cosmwasm-std = "1.1"
-cw2 = "0.14"
+cosmwasm-schema = "1.1.0"
+cosmwasm-std = "1.1.0"
+cw2 = "0.14.0"
 cw721 = { path = "../../packages/cw721" }
 cw721-base = { path = "../cw721-base", features = ["library"] }
-schemars = "0.8"
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+schemars = "0.8.10"
+serde = { version = "1.0.140", default-features = false, features = ["derive"] }

--- a/contracts/cw2981-royalties/schema/all_nft_info_response.json
+++ b/contracts/cw2981-royalties/schema/all_nft_info_response.json
@@ -24,6 +24,7 @@
       ]
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -44,7 +45,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Empty": {
       "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
@@ -117,7 +119,8 @@
             "null"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "OwnerOfResponse": {
       "type": "object",
@@ -137,7 +140,8 @@
           "description": "Owner of the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Timestamp": {
       "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",

--- a/contracts/cw2981-royalties/schema/check_royalties_response.json
+++ b/contracts/cw2981-royalties/schema/check_royalties_response.json
@@ -10,5 +10,6 @@
     "royalty_payments": {
       "type": "boolean"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/contracts/cw2981-royalties/schema/contract_info_response.json
+++ b/contracts/cw2981-royalties/schema/contract_info_response.json
@@ -13,5 +13,6 @@
     "symbol": {
       "type": "string"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/contracts/cw2981-royalties/schema/cw2981_query_msg.json
+++ b/contracts/cw2981-royalties/schema/cw2981_query_msg.json
@@ -22,7 +22,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -35,7 +36,8 @@
       ],
       "properties": {
         "check_royalties": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/contracts/cw2981-royalties/schema/execute_msg.json
+++ b/contracts/cw2981-royalties/schema/execute_msg.json
@@ -23,7 +23,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -52,7 +53,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -87,7 +89,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -112,7 +115,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -143,7 +147,8 @@
             "operator": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -164,7 +169,8 @@
             "operator": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -198,7 +204,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -219,7 +226,8 @@
             "msg": {
               "$ref": "#/definitions/Empty"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -313,7 +321,8 @@
             "null"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Timestamp": {
       "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",

--- a/contracts/cw2981-royalties/schema/instantiate_msg.json
+++ b/contracts/cw2981-royalties/schema/instantiate_msg.json
@@ -20,5 +20,6 @@
       "description": "Symbol of the NFT contract",
       "type": "string"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/contracts/cw2981-royalties/schema/minter_response.json
+++ b/contracts/cw2981-royalties/schema/minter_response.json
@@ -10,5 +10,6 @@
     "minter": {
       "type": "string"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/contracts/cw2981-royalties/schema/nft_info_response.json
+++ b/contracts/cw2981-royalties/schema/nft_info_response.json
@@ -22,6 +22,7 @@
       ]
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Empty": {
       "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",

--- a/contracts/cw2981-royalties/schema/num_tokens_response.json
+++ b/contracts/cw2981-royalties/schema/num_tokens_response.json
@@ -11,5 +11,6 @@
       "format": "uint64",
       "minimum": 0.0
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/contracts/cw2981-royalties/schema/operators_response.json
+++ b/contracts/cw2981-royalties/schema/operators_response.json
@@ -13,6 +13,7 @@
       }
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -33,7 +34,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",

--- a/contracts/cw2981-royalties/schema/owner_of_response.json
+++ b/contracts/cw2981-royalties/schema/owner_of_response.json
@@ -19,6 +19,7 @@
       "type": "string"
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -39,7 +40,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",

--- a/contracts/cw2981-royalties/schema/query_msg_for__cw2981_query_msg.json
+++ b/contracts/cw2981-royalties/schema/query_msg_for__cw2981_query_msg.json
@@ -25,7 +25,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -56,7 +57,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -83,7 +85,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -125,7 +128,8 @@
                 "null"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -138,7 +142,8 @@
       ],
       "properties": {
         "num_tokens": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -151,7 +156,8 @@
       ],
       "properties": {
         "contract_info": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -172,7 +178,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -200,7 +207,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -235,7 +243,8 @@
                 "null"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -264,7 +273,8 @@
                 "null"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -276,7 +286,8 @@
       ],
       "properties": {
         "minter": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -297,7 +308,8 @@
             "msg": {
               "$ref": "#/definitions/Cw2981QueryMsg"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -326,7 +338,8 @@
                 "token_id": {
                   "type": "string"
                 }
-              }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -339,7 +352,8 @@
           ],
           "properties": {
             "check_royalties": {
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "additionalProperties": false

--- a/contracts/cw2981-royalties/schema/royalties_info_response.json
+++ b/contracts/cw2981-royalties/schema/royalties_info_response.json
@@ -14,6 +14,7 @@
       "$ref": "#/definitions/Uint128"
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",

--- a/contracts/cw2981-royalties/schema/tokens_response.json
+++ b/contracts/cw2981-royalties/schema/tokens_response.json
@@ -13,5 +13,6 @@
         "type": "string"
       }
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/contracts/cw2981-royalties/src/lib.rs
+++ b/contracts/cw2981-royalties/src/lib.rs
@@ -3,20 +3,19 @@ pub mod query;
 
 pub use query::{check_royalties, query_royalties_info};
 
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
-use crate::msg::Cw2981QueryMsg;
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{to_binary, Empty};
 use cw2::set_contract_version;
 use cw721_base::Cw721Contract;
 pub use cw721_base::{ContractError, InstantiateMsg, MintMsg, MinterResponse};
 
+use crate::msg::Cw2981QueryMsg;
+
 // Version info for migration
 const CONTRACT_NAME: &str = "crates.io:cw2981-royalties";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+#[cw_serde]
 pub struct Trait {
     pub display_type: Option<String>,
     pub trait_type: String,
@@ -24,7 +23,8 @@ pub struct Trait {
 }
 
 // see: https://docs.opensea.io/docs/metadata-standards
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+#[cw_serde]
+#[derive(Default)]
 pub struct Metadata {
     pub image: Option<String>,
     pub image_data: Option<String>,

--- a/contracts/cw2981-royalties/src/msg.rs
+++ b/contracts/cw2981-royalties/src/msg.rs
@@ -1,10 +1,8 @@
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Uint128;
 use cw721::CustomMsg;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-#[serde(rename_all = "snake_case")]
+#[cw_serde]
 pub enum Cw2981QueryMsg {
     /// Should be called on sale to see if royalties are owed
     /// by the marketplace selling the NFT, if CheckRoyalties
@@ -34,7 +32,7 @@ impl Default for Cw2981QueryMsg {
 
 impl CustomMsg for Cw2981QueryMsg {}
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[cw_serde]
 pub struct RoyaltiesInfoResponse {
     pub address: String,
     // Note that this must be the same denom as that passed in to RoyaltyInfo
@@ -44,7 +42,7 @@ pub struct RoyaltiesInfoResponse {
 
 /// Shows if the contract implements royalties
 /// if royalty_payments is true, marketplaces should pay them
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[cw_serde]
 pub struct CheckRoyaltiesResponse {
     pub royalty_payments: bool,
 }

--- a/contracts/cw721-base/Cargo.toml
+++ b/contracts/cw721-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw721-base"
-version = "0.13.4"
+version = "0.14.0"
 authors = [
   "Ethan Frey <ethanfrey@users.noreply.github.com>",
   "Orkun Külçe <orkun@deuslabs.fi>",
@@ -28,14 +28,12 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw-utils = "0.13.4"
-cw2 = "0.13.4"
-cw721 = { path = "../../packages/cw721", version = "0.13.4" }
-cw-storage-plus = "0.13.4"
-cosmwasm-std = { version = "1.0.0" }
-schemars = "0.8.10"
-serde = { version = "1.0.140", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0.31" }
-
-[dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
+cosmwasm-schema = "1.1"
+cosmwasm-std = "1.1"
+cw2 = "0.14"
+cw721 = { path = "../../packages/cw721" }
+cw-storage-plus = "0.14"
+cw-utils = "0.14"
+schemars = "0.8"
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+thiserror = "1.0"

--- a/contracts/cw721-base/Cargo.toml
+++ b/contracts/cw721-base/Cargo.toml
@@ -28,12 +28,12 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-schema = "1.1"
-cosmwasm-std = "1.1"
-cw2 = "0.14"
+cosmwasm-schema = "1.1.0"
+cosmwasm-std = "1.1.0"
+cw2 = "0.14.0"
 cw721 = { path = "../../packages/cw721" }
-cw-storage-plus = "0.14"
-cw-utils = "0.14"
-schemars = "0.8"
-serde = { version = "1.0", default-features = false, features = ["derive"] }
-thiserror = "1.0"
+cw-storage-plus = "0.14.0"
+cw-utils = "0.14.0"
+schemars = "0.8.10"
+serde = { version = "1.0.140", default-features = false, features = ["derive"] }
+thiserror = "1.0.31"

--- a/contracts/cw721-base/Cargo.toml
+++ b/contracts/cw721-base/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
   "Ethan Frey <ethanfrey@users.noreply.github.com>",
   "Orkun Külçe <orkun@deuslabs.fi>",
 ]
-edition = "2018"
+edition = "2021"
 description = "Basic implementation cw721 NFTs"
 license = "Apache-2.0"
 repository = "https://github.com/CosmWasm/cw-nfts"

--- a/contracts/cw721-base/schema/all_nft_info_response.json
+++ b/contracts/cw721-base/schema/all_nft_info_response.json
@@ -24,6 +24,7 @@
       ]
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -44,7 +45,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Empty": {
       "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
@@ -117,7 +119,8 @@
             "null"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "OwnerOfResponse": {
       "type": "object",
@@ -137,7 +140,8 @@
           "description": "Owner of the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Timestamp": {
       "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",

--- a/contracts/cw721-base/schema/approval_response.json
+++ b/contracts/cw721-base/schema/approval_response.json
@@ -10,6 +10,7 @@
       "$ref": "#/definitions/Approval"
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -30,7 +31,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",

--- a/contracts/cw721-base/schema/approvals_response.json
+++ b/contracts/cw721-base/schema/approvals_response.json
@@ -13,6 +13,7 @@
       }
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -33,7 +34,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",

--- a/contracts/cw721-base/schema/contract_info_response.json
+++ b/contracts/cw721-base/schema/contract_info_response.json
@@ -13,5 +13,6 @@
     "symbol": {
       "type": "string"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/contracts/cw721-base/schema/execute_msg.json
+++ b/contracts/cw721-base/schema/execute_msg.json
@@ -23,7 +23,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -52,7 +53,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -87,7 +89,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -112,7 +115,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -143,7 +147,8 @@
             "operator": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -164,7 +169,8 @@
             "operator": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -198,7 +204,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -219,7 +226,8 @@
             "msg": {
               "$ref": "#/definitions/Empty"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -313,7 +321,8 @@
             "null"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Timestamp": {
       "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",

--- a/contracts/cw721-base/schema/instantiate_msg.json
+++ b/contracts/cw721-base/schema/instantiate_msg.json
@@ -20,5 +20,6 @@
       "description": "Symbol of the NFT contract",
       "type": "string"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/contracts/cw721-base/schema/minter_response.json
+++ b/contracts/cw721-base/schema/minter_response.json
@@ -10,5 +10,6 @@
     "minter": {
       "type": "string"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/contracts/cw721-base/schema/nft_info_response.json
+++ b/contracts/cw721-base/schema/nft_info_response.json
@@ -22,6 +22,7 @@
       ]
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Empty": {
       "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",

--- a/contracts/cw721-base/schema/num_tokens_response.json
+++ b/contracts/cw721-base/schema/num_tokens_response.json
@@ -11,5 +11,6 @@
       "format": "uint64",
       "minimum": 0.0
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/contracts/cw721-base/schema/operators_response.json
+++ b/contracts/cw721-base/schema/operators_response.json
@@ -13,6 +13,7 @@
       }
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -33,7 +34,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",

--- a/contracts/cw721-base/schema/owner_of_response.json
+++ b/contracts/cw721-base/schema/owner_of_response.json
@@ -19,6 +19,7 @@
       "type": "string"
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -39,7 +40,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",

--- a/contracts/cw721-base/schema/query_msg_for__empty.json
+++ b/contracts/cw721-base/schema/query_msg_for__empty.json
@@ -25,7 +25,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -56,7 +57,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -83,7 +85,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -125,7 +128,8 @@
                 "null"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -138,7 +142,8 @@
       ],
       "properties": {
         "num_tokens": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -151,7 +156,8 @@
       ],
       "properties": {
         "contract_info": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -172,7 +178,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -200,7 +207,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -235,7 +243,8 @@
                 "null"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -264,7 +273,8 @@
                 "null"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -276,7 +286,8 @@
       ],
       "properties": {
         "minter": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -297,7 +308,8 @@
             "msg": {
               "$ref": "#/definitions/Empty"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/contracts/cw721-base/schema/tokens_response.json
+++ b/contracts/cw721-base/schema/tokens_response.json
@@ -13,5 +13,6 @@
         "type": "string"
       }
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/contracts/cw721-base/src/helpers.rs
+++ b/contracts/cw721-base/src/helpers.rs
@@ -1,4 +1,6 @@
-use crate::{ExecuteMsg, QueryMsg};
+use std::marker::PhantomData;
+
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
     to_binary, Addr, CosmosMsg, CustomMsg, QuerierWrapper, StdResult, WasmMsg, WasmQuery,
 };
@@ -6,11 +8,12 @@ use cw721::{
     AllNftInfoResponse, Approval, ApprovalResponse, ApprovalsResponse, ContractInfoResponse,
     NftInfoResponse, NumTokensResponse, OperatorsResponse, OwnerOfResponse, TokensResponse,
 };
-use serde::__private::PhantomData;
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+use crate::{ExecuteMsg, QueryMsg};
+
+#[cw_serde]
 pub struct Cw721Contract<Q: CustomMsg, E: CustomMsg>(
     pub Addr,
     pub PhantomData<Q>,

--- a/contracts/cw721-base/src/msg.rs
+++ b/contracts/cw721-base/src/msg.rs
@@ -1,10 +1,8 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Binary;
 use cw721::Expiration;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[cw_serde]
 pub struct InstantiateMsg {
     /// Name of the NFT contract
     pub name: String,
@@ -20,8 +18,7 @@ pub struct InstantiateMsg {
 /// This is like Cw721ExecuteMsg but we add a Mint command for an owner
 /// to make this stand-alone. You will likely want to remove mint and
 /// use other control logic in any contract that inherits this.
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-#[serde(rename_all = "snake_case")]
+#[cw_serde]
 pub enum ExecuteMsg<T, E> {
     /// Transfer is a base message to move a token to another account without triggering actions
     TransferNft { recipient: String, token_id: String },
@@ -60,7 +57,7 @@ pub enum ExecuteMsg<T, E> {
     Extension { msg: E },
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[cw_serde]
 pub struct MintMsg<T> {
     /// Unique ID of the NFT
     pub token_id: String,
@@ -74,8 +71,7 @@ pub struct MintMsg<T> {
     pub extension: T,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
+#[cw_serde]
 pub enum QueryMsg<Q> {
     /// Return the owner of the given token, error if token does not exist
     /// Return type: OwnerOfResponse
@@ -153,7 +149,7 @@ pub enum QueryMsg<Q> {
 }
 
 /// Shows who can mint these tokens
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[cw_serde]
 pub struct MinterResponse {
     pub minter: String,
 }

--- a/contracts/cw721-fixed-price/Cargo.toml
+++ b/contracts/cw721-fixed-price/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cw721-fixed-price"
 version = "0.14.0"
 authors = ["Vernon Johnson <vtj2105@columbia.edu>"]
-edition = "2018"
+edition = "2021"
 
 exclude = [
   # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.

--- a/contracts/cw721-fixed-price/Cargo.toml
+++ b/contracts/cw721-fixed-price/Cargo.toml
@@ -40,16 +40,16 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-schema = "1.1"
-cosmwasm-std = "1.1"
-cw2 = "0.14"
+cosmwasm-schema = "1.1.0"
+cosmwasm-std = "1.1.0"
+cw2 = "0.14.0"
 cw721-base = { path = "../cw721-base", features = ["library"] }
-cw-storage-plus = "0.14"
-cw-utils = "0.14"
-cw20 = "0.14"
-schemars = "0.8"
-serde = { version = "1.0", default-features = false, features = ["derive"] }
-thiserror = "1.0"
+cw-storage-plus = "0.14.0"
+cw-utils = "0.14.0"
+cw20 = "0.14.0"
+schemars = "0.8.10"
+serde = { version = "1.0.140", default-features = false, features = ["derive"] }
+thiserror = "1.0.31"
 
 [dev-dependencies]
 prost = "0.10"

--- a/contracts/cw721-fixed-price/Cargo.toml
+++ b/contracts/cw721-fixed-price/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw721-fixed-price"
-version = "0.13.4"
+version = "0.14.0"
 authors = ["Vernon Johnson <vtj2105@columbia.edu>"]
 edition = "2018"
 
@@ -40,20 +40,16 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0" }
-cosmwasm-storage = { version = "1.0.0" }
-cw-storage-plus = "0.13.4"
-cw2 = "0.13.4"
-schemars = "0.8.10"
-cw721-base = { path = "../cw721-base", version = "0.13.4", features = [
-  "library",
-] }
-cw20 = "0.13.4"
-serde = { version = "1.0.140", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0.31" }
-cw-utils = "0.13.4"
-prost = "0.10.4"
-cw3 = "0.13.4"
+cosmwasm-schema = "1.1"
+cosmwasm-std = "1.1"
+cw2 = "0.14"
+cw721-base = { path = "../cw721-base", features = ["library"] }
+cw-storage-plus = "0.14"
+cw-utils = "0.14"
+cw20 = "0.14"
+schemars = "0.8"
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+thiserror = "1.0"
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
+prost = "0.10"

--- a/contracts/cw721-fixed-price/schema/config_response.json
+++ b/contracts/cw721-fixed-price/schema/config_response.json
@@ -62,6 +62,7 @@
       "minimum": 0.0
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Addr": {
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",

--- a/contracts/cw721-fixed-price/schema/instantiate_msg.json
+++ b/contracts/cw721-fixed-price/schema/instantiate_msg.json
@@ -52,6 +52,7 @@
       "$ref": "#/definitions/Uint128"
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Addr": {
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",

--- a/contracts/cw721-fixed-price/schema/query_msg.json
+++ b/contracts/cw721-fixed-price/schema/query_msg.json
@@ -9,7 +9,8 @@
       ],
       "properties": {
         "get_config": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/contracts/cw721-fixed-price/src/msg.rs
+++ b/contracts/cw721-fixed-price/src/msg.rs
@@ -1,10 +1,9 @@
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Uint128};
 use cw20::Cw20ReceiveMsg;
 use cw721_base::Extension;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[cw_serde]
 pub struct InstantiateMsg {
     pub owner: Addr,
     pub max_tokens: u32,
@@ -17,19 +16,17 @@ pub struct InstantiateMsg {
     pub extension: Extension,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
+#[cw_serde]
 pub enum ExecuteMsg {
     Receive(Cw20ReceiveMsg),
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
+#[cw_serde]
 pub enum QueryMsg {
     GetConfig {},
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[cw_serde]
 pub struct ConfigResponse {
     pub owner: Addr,
     pub cw20_address: Addr,

--- a/contracts/cw721-fixed-price/src/state.rs
+++ b/contracts/cw721-fixed-price/src/state.rs
@@ -1,11 +1,9 @@
-use cw721_base::Extension;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Uint128};
+use cw721_base::Extension;
 use cw_storage_plus::Item;
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[cw_serde]
 pub struct Config {
     pub owner: Addr,
     pub cw20_address: Addr,

--- a/contracts/cw721-metadata-onchain/Cargo.toml
+++ b/contracts/cw721-metadata-onchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw721-metadata-onchain"
-version = "0.13.4"
+version = "0.14.0"
 authors = [
   "Ethan Frey <ethanfrey@users.noreply.github.com>",
   "Orkun Külçe <orkun@deuslabs.fi>",
@@ -28,15 +28,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cw2 = "0.13.4"
-cw721 = { path = "../../packages/cw721", version = "0.13.4" }
-cw721-base = { path = "../cw721-base", version = "0.13.4", features = [
-  "library",
-] }
-cosmwasm-std = { version = "1.0.0" }
-schemars = "0.8.10"
-serde = { version = "1.0.140", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0.31" }
-
-[dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
+cosmwasm-schema = "1.1"
+cosmwasm-std = "1.1"
+cw2 = "0.14"
+cw721 = { path = "../../packages/cw721" }
+cw721-base = { path = "../cw721-base", features = ["library"] }
+schemars = "0.8"
+serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/contracts/cw721-metadata-onchain/Cargo.toml
+++ b/contracts/cw721-metadata-onchain/Cargo.toml
@@ -28,10 +28,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-schema = "1.1"
-cosmwasm-std = "1.1"
-cw2 = "0.14"
+cosmwasm-schema = "1.1.0"
+cosmwasm-std = "1.1.0"
+cw2 = "0.14.0"
 cw721 = { path = "../../packages/cw721" }
 cw721-base = { path = "../cw721-base", features = ["library"] }
-schemars = "0.8"
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+schemars = "0.8.10"
+serde = { version = "1.0.140", default-features = false, features = ["derive"] }

--- a/contracts/cw721-metadata-onchain/Cargo.toml
+++ b/contracts/cw721-metadata-onchain/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
   "Ethan Frey <ethanfrey@users.noreply.github.com>",
   "Orkun Külçe <orkun@deuslabs.fi>",
 ]
-edition = "2018"
+edition = "2021"
 description = "Example extending CW721 NFT to store metadata on chain"
 license = "Apache-2.0"
 repository = "https://github.com/CosmWasm/cw-nfts"

--- a/contracts/cw721-metadata-onchain/schema/all_nft_info_response.json
+++ b/contracts/cw721-metadata-onchain/schema/all_nft_info_response.json
@@ -24,6 +24,7 @@
       ]
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -44,7 +45,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
@@ -152,7 +154,8 @@
             "null"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "NftInfoResponse_for_Nullable_Metadata": {
       "type": "object",
@@ -175,7 +178,8 @@
             "null"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "OwnerOfResponse": {
       "type": "object",
@@ -195,7 +199,8 @@
           "description": "Owner of the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Timestamp": {
       "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
@@ -224,7 +229,8 @@
         "value": {
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Uint64": {
       "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",

--- a/contracts/cw721-metadata-onchain/schema/approval_response.json
+++ b/contracts/cw721-metadata-onchain/schema/approval_response.json
@@ -10,6 +10,7 @@
       "$ref": "#/definitions/Approval"
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -30,7 +31,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",

--- a/contracts/cw721-metadata-onchain/schema/approvals_response.json
+++ b/contracts/cw721-metadata-onchain/schema/approvals_response.json
@@ -13,6 +13,7 @@
       }
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -33,7 +34,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",

--- a/contracts/cw721-metadata-onchain/schema/contract_info_response.json
+++ b/contracts/cw721-metadata-onchain/schema/contract_info_response.json
@@ -13,5 +13,6 @@
     "symbol": {
       "type": "string"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/contracts/cw721-metadata-onchain/schema/execute_msg.json
+++ b/contracts/cw721-metadata-onchain/schema/execute_msg.json
@@ -23,7 +23,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -52,7 +53,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -87,7 +89,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -112,7 +115,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -143,7 +147,8 @@
             "operator": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -164,7 +169,8 @@
             "operator": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -198,7 +204,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -219,7 +226,8 @@
             "msg": {
               "$ref": "#/definitions/Empty"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -340,7 +348,8 @@
             "null"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "MintMsg_for_Nullable_Metadata": {
       "type": "object",
@@ -375,7 +384,8 @@
             "null"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Timestamp": {
       "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
@@ -404,7 +414,8 @@
         "value": {
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Uint64": {
       "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",

--- a/contracts/cw721-metadata-onchain/schema/instantiate_msg.json
+++ b/contracts/cw721-metadata-onchain/schema/instantiate_msg.json
@@ -20,5 +20,6 @@
       "description": "Symbol of the NFT contract",
       "type": "string"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/contracts/cw721-metadata-onchain/schema/minter_response.json
+++ b/contracts/cw721-metadata-onchain/schema/minter_response.json
@@ -10,5 +10,6 @@
     "minter": {
       "type": "string"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/contracts/cw721-metadata-onchain/schema/nft_info_response.json
+++ b/contracts/cw721-metadata-onchain/schema/nft_info_response.json
@@ -22,6 +22,7 @@
       ]
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Metadata": {
       "type": "object",
@@ -83,7 +84,8 @@
             "null"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Trait": {
       "type": "object",
@@ -104,7 +106,8 @@
         "value": {
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/contracts/cw721-metadata-onchain/schema/num_tokens_response.json
+++ b/contracts/cw721-metadata-onchain/schema/num_tokens_response.json
@@ -11,5 +11,6 @@
       "format": "uint64",
       "minimum": 0.0
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/contracts/cw721-metadata-onchain/schema/operators_response.json
+++ b/contracts/cw721-metadata-onchain/schema/operators_response.json
@@ -13,6 +13,7 @@
       }
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -33,7 +34,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",

--- a/contracts/cw721-metadata-onchain/schema/owner_of_response.json
+++ b/contracts/cw721-metadata-onchain/schema/owner_of_response.json
@@ -19,6 +19,7 @@
       "type": "string"
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -39,7 +40,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",

--- a/contracts/cw721-metadata-onchain/schema/query_msg_for__empty.json
+++ b/contracts/cw721-metadata-onchain/schema/query_msg_for__empty.json
@@ -25,7 +25,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -56,7 +57,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -83,7 +85,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -125,7 +128,8 @@
                 "null"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -138,7 +142,8 @@
       ],
       "properties": {
         "num_tokens": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -151,7 +156,8 @@
       ],
       "properties": {
         "contract_info": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -172,7 +178,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -200,7 +207,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -235,7 +243,8 @@
                 "null"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -264,7 +273,8 @@
                 "null"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -276,7 +286,8 @@
       ],
       "properties": {
         "minter": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -297,7 +308,8 @@
             "msg": {
               "$ref": "#/definitions/Empty"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/contracts/cw721-metadata-onchain/schema/tokens_response.json
+++ b/contracts/cw721-metadata-onchain/schema/tokens_response.json
@@ -13,5 +13,6 @@
         "type": "string"
       }
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/contracts/cw721-metadata-onchain/src/lib.rs
+++ b/contracts/cw721-metadata-onchain/src/lib.rs
@@ -1,6 +1,4 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Empty;
 use cw2::set_contract_version;
 pub use cw721_base::{ContractError, InstantiateMsg, MintMsg, MinterResponse};
@@ -9,7 +7,7 @@ pub use cw721_base::{ContractError, InstantiateMsg, MintMsg, MinterResponse};
 const CONTRACT_NAME: &str = "crates.io:cw721-metadata-onchain";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+#[cw_serde]
 pub struct Trait {
     pub display_type: Option<String>,
     pub trait_type: String,
@@ -17,7 +15,8 @@ pub struct Trait {
 }
 
 // see: https://docs.opensea.io/docs/metadata-standards
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug, Default)]
+#[cw_serde]
+#[derive(Default)]
 pub struct Metadata {
     pub image: Option<String>,
     pub image_data: Option<String>,

--- a/packages/cw721/Cargo.toml
+++ b/packages/cw721/Cargo.toml
@@ -13,8 +13,8 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cosmwasm-schema = "1.1"
-cosmwasm-std = "1.1"
-cw-utils = "0.14"
-schemars = "0.8"
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+cosmwasm-schema = "1.1.0"
+cosmwasm-std = "1.1.0"
+cw-utils = "0.14.0"
+schemars = "0.8.10"
+serde = { version = "1.0.140", default-features = false, features = ["derive"] }

--- a/packages/cw721/Cargo.toml
+++ b/packages/cw721/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Ethan Frey <ethanfrey@users.noreply.github.com>",
     "Orkun Külçe <orkun@deuslabs.fi>",
 ]
-edition = "2018"
+edition = "2021"
 description = "Definition and types for the CosmWasm-721 NFT interface"
 license = "Apache-2.0"
 repository = "https://github.com/CosmWasm/cw-nfts"

--- a/packages/cw721/Cargo.toml
+++ b/packages/cw721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw721"
-version = "0.13.4"
+version = "0.14.0"
 authors = [
     "Ethan Frey <ethanfrey@users.noreply.github.com>",
     "Orkun Külçe <orkun@deuslabs.fi>",
@@ -13,10 +13,8 @@ homepage = "https://cosmwasm.com"
 documentation = "https://docs.cosmwasm.com"
 
 [dependencies]
-cw-utils = "0.13.4"
-cosmwasm-std = { version = "1.0.0" }
-schemars = "0.8.10"
-serde = { version = "1.0.140", default-features = false, features = ["derive"] }
-
-[dev-dependencies]
-cosmwasm-schema = { version = "1.0.0" }
+cosmwasm-schema = "1.1"
+cosmwasm-std = "1.1"
+cw-utils = "0.14"
+schemars = "0.8"
+serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/packages/cw721/schema/all_nft_info_response.json
+++ b/packages/cw721/schema/all_nft_info_response.json
@@ -24,6 +24,7 @@
       ]
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -44,7 +45,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Empty": {
       "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
@@ -117,7 +119,8 @@
             "null"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "OwnerOfResponse": {
       "type": "object",
@@ -137,7 +140,8 @@
           "description": "Owner of the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Timestamp": {
       "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",

--- a/packages/cw721/schema/approval_response.json
+++ b/packages/cw721/schema/approval_response.json
@@ -10,6 +10,7 @@
       "$ref": "#/definitions/Approval"
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -30,7 +31,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",

--- a/packages/cw721/schema/approvals_response.json
+++ b/packages/cw721/schema/approvals_response.json
@@ -13,6 +13,7 @@
       }
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -33,7 +34,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",

--- a/packages/cw721/schema/contract_info_response.json
+++ b/packages/cw721/schema/contract_info_response.json
@@ -13,5 +13,6 @@
     "symbol": {
       "type": "string"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/packages/cw721/schema/cw721_execute_msg.json
+++ b/packages/cw721/schema/cw721_execute_msg.json
@@ -22,7 +22,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -51,7 +52,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -86,7 +88,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -111,7 +114,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -142,7 +146,8 @@
             "operator": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -163,7 +168,8 @@
             "operator": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -184,7 +190,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/packages/cw721/schema/cw721_query_msg.json
+++ b/packages/cw721/schema/cw721_query_msg.json
@@ -25,7 +25,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -56,7 +57,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -83,7 +85,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -125,7 +128,8 @@
                 "null"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -138,7 +142,8 @@
       ],
       "properties": {
         "num_tokens": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -151,7 +156,8 @@
       ],
       "properties": {
         "contract_info": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -172,7 +178,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -200,7 +207,8 @@
             "token_id": {
               "type": "string"
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -235,7 +243,8 @@
                 "null"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -264,7 +273,8 @@
                 "null"
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/packages/cw721/schema/cw721_receive_msg.json
+++ b/packages/cw721/schema/cw721_receive_msg.json
@@ -19,6 +19,7 @@
       "type": "string"
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Binary": {
       "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",

--- a/packages/cw721/schema/nft_info_response.json
+++ b/packages/cw721/schema/nft_info_response.json
@@ -22,6 +22,7 @@
       ]
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Empty": {
       "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",

--- a/packages/cw721/schema/num_tokens_response.json
+++ b/packages/cw721/schema/num_tokens_response.json
@@ -11,5 +11,6 @@
       "format": "uint64",
       "minimum": 0.0
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/packages/cw721/schema/operators_response.json
+++ b/packages/cw721/schema/operators_response.json
@@ -13,6 +13,7 @@
       }
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -33,7 +34,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",

--- a/packages/cw721/schema/owner_of_response.json
+++ b/packages/cw721/schema/owner_of_response.json
@@ -19,6 +19,7 @@
       "type": "string"
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Approval": {
       "type": "object",
@@ -39,7 +40,8 @@
           "description": "Account that can transfer/send the token",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Expiration": {
       "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",

--- a/packages/cw721/schema/tokens_response.json
+++ b/packages/cw721/schema/tokens_response.json
@@ -13,5 +13,6 @@
         "type": "string"
       }
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/packages/cw721/src/msg.rs
+++ b/packages/cw721/src/msg.rs
@@ -1,11 +1,8 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Binary;
 use cw_utils::Expiration;
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-#[serde(rename_all = "snake_case")]
+#[cw_serde]
 pub enum Cw721ExecuteMsg {
     /// Transfer is a base message to move a token to another account without triggering actions
     TransferNft { recipient: String, token_id: String },

--- a/packages/cw721/src/query.rs
+++ b/packages/cw721/src/query.rs
@@ -1,10 +1,7 @@
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-
+use cosmwasm_schema::cw_serde;
 use cw_utils::Expiration;
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-#[serde(rename_all = "snake_case")]
+#[cw_serde]
 pub enum Cw721QueryMsg {
     /// Return the owner of the given token, error if token does not exist
     /// Return type: OwnerOfResponse
@@ -71,7 +68,7 @@ pub enum Cw721QueryMsg {
     },
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[cw_serde]
 pub struct OwnerOfResponse {
     /// Owner of the token
     pub owner: String,
@@ -79,7 +76,7 @@ pub struct OwnerOfResponse {
     pub approvals: Vec<Approval>,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[cw_serde]
 pub struct Approval {
     /// Account that can transfer/send the token
     pub spender: String,
@@ -87,33 +84,33 @@ pub struct Approval {
     pub expires: Expiration,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[cw_serde]
 pub struct ApprovalResponse {
     pub approval: Approval,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[cw_serde]
 pub struct ApprovalsResponse {
     pub approvals: Vec<Approval>,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[cw_serde]
 pub struct OperatorsResponse {
     pub operators: Vec<Approval>,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[cw_serde]
 pub struct NumTokensResponse {
     pub count: u64,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[cw_serde]
 pub struct ContractInfoResponse {
     pub name: String,
     pub symbol: String,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[cw_serde]
 pub struct NftInfoResponse<T> {
     /// Universal resource identifier for this NFT
     /// Should point to a JSON file that conforms to the ERC721
@@ -123,7 +120,7 @@ pub struct NftInfoResponse<T> {
     pub extension: T,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[cw_serde]
 pub struct AllNftInfoResponse<T> {
     /// Who can transfer the token
     pub access: OwnerOfResponse,
@@ -131,7 +128,7 @@ pub struct AllNftInfoResponse<T> {
     pub info: NftInfoResponse<T>,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[cw_serde]
 pub struct TokensResponse {
     /// Contains all token_ids in lexicographical ordering
     /// If there are more than `limit`, use `start_from` in future queries

--- a/packages/cw721/src/receiver.rs
+++ b/packages/cw721/src/receiver.rs
@@ -1,11 +1,10 @@
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{to_binary, Binary, CosmosMsg, StdResult, WasmMsg};
 
 /// Cw721ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-#[serde(rename_all = "snake_case")]
+#[cw_serde]
 pub struct Cw721ReceiveMsg {
     pub sender: String,
     pub token_id: String,
@@ -36,8 +35,7 @@ impl Cw721ReceiveMsg {
 
 /// This is just a helper to properly serialize the above message.
 /// The actual receiver should include this variant in the larger ExecuteMsg enum
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
-#[serde(rename_all = "snake_case")]
+#[cw_serde]
 enum ReceiverExecuteMsg {
     ReceiveNft(Cw721ReceiveMsg),
 }


### PR DESCRIPTION
## Changes

* Versioning
  - Bump Rust edition to 2021
  - Bump `cosmwasm-std` to v1.1
  - Bump `cw-plus` packages to `v0.14`
  - Bump all contracts and packages in this repo to `v0.14` to be consistent with cw-plus

* CI
  - Bump Rust version used in CI to v1.60.0 (was 1.58.1)
  - Bump cosmwasm-vm used in CI to v1.1.0 (was 1.0.0-beta8)

* Dependencies
  - Order all dependencies alphabetically
  - Removed a few unused dependencies
  - Moved a few dependencies that are only used in tests to dev-dependencies

* Schema
  - Replace the derive statement with the new `cw_serde` decorator, and regenerate schema accordingly:

```diff
- #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
- #[serde(rename_all = "snake_case")]
+ #[cw_serde]
```

* Imports
  - in `cw721-base/src/helpers.rs` it imports the wrong `PhantomData`:

```diff
- use serde::__private::PhantomData;
+ use std::markers::PhantomData;
```

I assume this is because someone used editor auto-completion for imports...

## Notes

* The most powerful feature provided by cw v1.1, the query response derivation, does not work with cw721-base because it doesn't support query msgs that contain generics. I suggest removing `QueryMsg::Extension`.
* For types that contain generics, it is necessary to rename them when generating schemas. See [this example](https://github.com/CosmWasm/cw-nfts/blob/v0.13.4/contracts/cw721-base/examples/schema.rs#L21-L25). That is, you want `query_msg.json` instead of `query_msg_for__cw2891_query_msg.json`. The latter won't be picked up by the ts-codegen so is kinda useless.