### PR TITLE
Use cargo workspace feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ workflows:
 jobs:
   contract_cw721_base:
     docker:
-      - image: rust:1.60.0
+      - image: rust:1.64.0
     working_directory: ~/project/contracts/cw721-base
     steps:
       - checkout:
@@ -31,7 +31,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw721-base-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw721-base-rust:1.64.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -53,11 +53,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw721-base-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw721-base-rust:1.64.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw721_metadata_onchain:
     docker:
-      - image: rust:1.60.0
+      - image: rust:1.64.0
     working_directory: ~/project/contracts/cw721-metadata-onchain
     steps:
       - checkout:
@@ -67,7 +67,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw721-metadata-onchain-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw721-metadata-onchain-rust:1.64.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -89,11 +89,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw721-metadata-onchain-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw721-metadata-onchain-rust:1.64.0-{{ checksum "~/project/Cargo.lock" }}
 
   contract_cw721_fixed_price:
     docker:
-      - image: rust:1.60.0
+      - image: rust:1.64.0
     working_directory: ~/project/contracts/cw721-fixed-price
     steps:
       - checkout:
@@ -103,7 +103,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-cw721-fixed-price-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-cw721-fixed-price-rust:1.64.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Unit Tests
           environment:
@@ -125,11 +125,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-cw721-fixed-price-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-cw721-fixed-price-rust:1.64.0-{{ checksum "~/project/Cargo.lock" }}
 
   package_cw721:
     docker:
-      - image: rust:1.60.0
+      - image: rust:1.64.0
     working_directory: ~/project/packages/cw721
     steps:
       - checkout:
@@ -139,7 +139,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-cw721:1.60.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-v2-cw721:1.64.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Build library for native target
           command: cargo build --locked
@@ -162,11 +162,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-cw721:1.60.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-v2-cw721:1.64.0-{{ checksum "~/project/Cargo.lock" }}
 
   lint:
     docker:
-      - image: rust:1.60.0
+      - image: rust:1.64.0
     steps:
       - checkout
       - run:
@@ -174,7 +174,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-lint-rust:1.60.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-lint-rust:1.64.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add rustfmt component
           command: rustup component add rustfmt
@@ -193,7 +193,7 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-lint-rust:1.60.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-lint-rust:1.64.0-{{ checksum "Cargo.lock" }}
 
   # This runs one time on the top level to ensure all contracts compile properly into wasm.
   # We don't run the wasm build per contract build, and then reuse a lot of the same dependencies, so this speeds up CI time
@@ -201,7 +201,7 @@ jobs:
   # We also sanity-check the resultant wasm files.
   wasm-build:
     docker:
-      - image: rust:1.60.0
+      - image: rust:1.64.0
     steps:
       - checkout:
           path: ~/project
@@ -210,7 +210,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargocache-wasm-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
+            - cargocache-wasm-rust:1.64.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown
@@ -230,7 +230,7 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-wasm-rust:1.60.0-{{ checksum "~/project/Cargo.lock" }}
+          key: cargocache-wasm-rust:1.64.0-{{ checksum "~/project/Cargo.lock" }}
       - run:
           name: Check wasm contracts
           command: cosmwasm-check ./target/wasm32-unknown-unknown/release/*.wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,19 +248,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cw3"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961f6959e04de1bc61f4fc3f333bc039998e2aedeab4aa79ba48239cf2d3edfa"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-utils",
- "schemars",
- "serde",
-]
-
-[[package]]
 name = "cw721"
 version = "0.15.0"
 dependencies = [
@@ -296,7 +283,6 @@ dependencies = [
  "cw-utils",
  "cw2",
  "cw20",
- "cw3",
  "cw721-base",
  "prost",
  "schemars",
@@ -493,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bf247779e67a9082a4790b45e71ac7cfd1321331a5c856a74a9faebdab78d0"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,27 @@
 [workspace]
 members = ["packages/*", "contracts/*"]
 
+[workspace.package]
+version       = "0.15.0"
+edition       = "2021"
+license       = "Apache-2.0"
+repository    = "https://github.com/CosmWasm/cw-nfts"
+homepage      = "https://cosmwasm.com"
+documentation = "https://docs.cosmwasm.com"
+
+[workspace.dependencies]
+cosmwasm-schema = "1.1.0"
+cosmwasm-std    = "1.1.0"
+cw2             = "0.15.0"
+cw20            = "0.15.0"
+cw721           = { version = "0.15.0", path = "./packages/cw721" }
+cw721-base      = { version = "0.15.0", path = "./contracts/cw721-base" }
+cw-storage-plus = "0.15.0"
+cw-utils        = "0.15.0"
+schemars        = "0.8.10"
+serde           = { version = "1.0.140", default-features = false, features = ["derive"] }
+thiserror       = "1.0.31"
+
 [profile.release.package.cw721-base]
 codegen-units = 1
 incremental = false

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/workspace-optimizer:0.12.6
+  cosmwasm/workspace-optimizer:0.12.9

--- a/contracts/cw2981-royalties/Cargo.toml
+++ b/contracts/cw2981-royalties/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "cw2981-royalties"
-version = "0.15.0"
-authors = ["Alex Lynham <alex@lynh.am>"]
-edition = "2021"
-description = "Basic implementation of royalties for cw721 NFTs with token level royalties"
-license = "Apache-2.0"
-repository = "https://github.com/CosmWasm/cw-nfts"
-homepage = "https://cosmwasm.com"
-documentation = "https://docs.cosmwasm.com"
+name          = "cw2981-royalties"
+description   = "Basic implementation of royalties for cw721 NFTs with token level royalties"
+authors       = ["Alex Lynham <alex@lynh.am>"]
+version       = { workspace = true }
+edition       = { workspace = true }
+license       = { workspace = true }
+repository    = { workspace = true }
+homepage      = { workspace = true }
+documentation = { workspace = true }
 
 exclude = [
   # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
@@ -25,12 +25,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-schema = "1.1.0"
-cosmwasm-std = "1.1.0"
-cw2 = "0.15.0"
-cw721 = { path = "../../packages/cw721", version = "0.15.0" }
-cw721-base = { path = "../cw721-base", version = "0.15.0", features = [
-  "library",
-] }
-schemars = "0.8.10"
-serde = { version = "1.0.140", default-features = false, features = ["derive"] }
+cosmwasm-schema = { workspace = true }
+cosmwasm-std    = { workspace = true }
+cw2             = { workspace = true }
+cw721           = { workspace = true }
+cw721-base      = { workspace = true, features = ["library"] }
+schemars        = { workspace = true }
+serde           = { workspace = true }

--- a/contracts/cw2981-royalties/Cargo.toml
+++ b/contracts/cw2981-royalties/Cargo.toml
@@ -9,12 +9,6 @@ repository    = { workspace = true }
 homepage      = { workspace = true }
 documentation = { workspace = true }
 
-exclude = [
-  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
-  "artifacts/*",
-]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/contracts/cw721-base/Cargo.toml
+++ b/contracts/cw721-base/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name = "cw721-base"
-version = "0.15.0"
-authors = [
+name          = "cw721-base"
+description   = "Basic implementation cw721 NFTs"
+authors       = [
   "Ethan Frey <ethanfrey@users.noreply.github.com>",
   "Orkun Külçe <orkun@deuslabs.fi>",
 ]
-edition = "2021"
-description = "Basic implementation cw721 NFTs"
-license = "Apache-2.0"
-repository = "https://github.com/CosmWasm/cw-nfts"
-homepage = "https://cosmwasm.com"
-documentation = "https://docs.cosmwasm.com"
+version       = { workspace = true }
+edition       = { workspace = true }
+license       = { workspace = true }
+repository    = { workspace = true }
+homepage      = { workspace = true }
+documentation = { workspace = true }
 
 exclude = [
   # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
@@ -28,12 +28,12 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-schema = "1.1.0"
-cosmwasm-std = "1.1.0"
-cw-utils = "0.15.0"
-cw2 = "0.15.0"
-cw721 = { path = "../../packages/cw721", version = "0.15.0" }
-cw-storage-plus = "0.15.0"
-schemars = "0.8.10"
-serde = { version = "1.0.140", default-features = false, features = ["derive"] }
-thiserror = "1.0.31"
+cosmwasm-schema = { workspace = true }
+cosmwasm-std    = { workspace = true }
+cw-utils        = { workspace = true }
+cw2             = { workspace = true }
+cw721           = { workspace = true }
+cw-storage-plus = { workspace = true }
+schemars        = { workspace = true }
+serde           = { workspace = true }
+thiserror       = { workspace = true }

--- a/contracts/cw721-base/Cargo.toml
+++ b/contracts/cw721-base/Cargo.toml
@@ -12,12 +12,6 @@ repository    = { workspace = true }
 homepage      = { workspace = true }
 documentation = { workspace = true }
 
-exclude = [
-  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
-  "artifacts/*",
-]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/contracts/cw721-fixed-price/Cargo.toml
+++ b/contracts/cw721-fixed-price/Cargo.toml
@@ -8,14 +8,6 @@ repository    = { workspace = true }
 homepage      = { workspace = true }
 documentation = { workspace = true }
 
-exclude = [
-  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
-  "contract.wasm",
-  "hash.txt",
-]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/contracts/cw721-fixed-price/Cargo.toml
+++ b/contracts/cw721-fixed-price/Cargo.toml
@@ -38,4 +38,4 @@ serde           = { workspace = true }
 thiserror       = { workspace = true }
 
 [dev-dependencies]
-prost = "0.10.4"
+prost = "0.10"

--- a/contracts/cw721-fixed-price/Cargo.toml
+++ b/contracts/cw721-fixed-price/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
-name = "cw721-fixed-price"
-version = "0.15.0"
-authors = ["Vernon Johnson <vtj2105@columbia.edu>"]
-edition = "2021"
+name          = "cw721-fixed-price"
+authors       = ["Vernon Johnson <vtj2105@columbia.edu>"]
+version       = { workspace = true }
+edition       = { workspace = true }
+license       = { workspace = true }
+repository    = { workspace = true }
+homepage      = { workspace = true }
+documentation = { workspace = true }
 
 exclude = [
   # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
@@ -15,45 +19,23 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-opt-level = 3
-debug = false
-rpath = false
-lto = true
-debug-assertions = false
-codegen-units = 1
-panic = 'abort'
-incremental = false
-overflow-checks = true
-
 [features]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
 
-[package.metadata.scripts]
-optimize = """docker run --rm -v "$(pwd)":/code \
-  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
-  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.6
-"""
-
 [dependencies]
-cosmwasm-schema = "1.1.0"
-cosmwasm-std = "1.1.0"
-cw-storage-plus = "0.15.0"
-cw2 = "0.15.0"
-schemars = "0.8.10"
-cw721-base = { path = "../cw721-base", version = "0.15.0", features = [
-  "library",
-] }
-cw20 = "0.15.0"
-serde = { version = "1.0.140", default-features = false, features = ["derive"] }
-thiserror = { version = "1.0.31" }
-cw-utils = "0.15.0"
-prost = "0.10.4"
-cw3 = "0.15.0"
+cosmwasm-schema = { workspace = true }
+cosmwasm-std    = { workspace = true }
+cw2             = { workspace = true }
+cw20            = { workspace = true }
+cw721-base      = { workspace = true, features = ["library"] }
+cw-storage-plus = { workspace = true }
+cw-utils        = { workspace = true }
+schemars        = { workspace = true }
+serde           = { workspace = true }
+thiserror       = { workspace = true }
 
 [dev-dependencies]
-prost = "0.10"
+prost = "0.10.4"

--- a/contracts/cw721-metadata-onchain/Cargo.toml
+++ b/contracts/cw721-metadata-onchain/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name = "cw721-metadata-onchain"
-version = "0.15.0"
-authors = [
+name          = "cw721-metadata-onchain"
+description   = "Example extending CW721 NFT to store metadata on chain"
+authors       = [
   "Ethan Frey <ethanfrey@users.noreply.github.com>",
   "Orkun Külçe <orkun@deuslabs.fi>",
 ]
-edition = "2021"
-description = "Example extending CW721 NFT to store metadata on chain"
-license = "Apache-2.0"
-repository = "https://github.com/CosmWasm/cw-nfts"
-homepage = "https://cosmwasm.com"
-documentation = "https://docs.cosmwasm.com"
+version       = { workspace = true }
+edition       = { workspace = true }
+license       = { workspace = true }
+repository    = { workspace = true }
+homepage      = { workspace = true }
+documentation = { workspace = true }
 
 exclude = [
   # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
@@ -28,12 +28,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-schema = "1.1.0"
-cosmwasm-std = "1.1.0"
-cw2 = "0.15.0"
-cw721 = { path = "../../packages/cw721", version = "0.15.0" }
-cw721-base = { path = "../cw721-base", version = "0.15.0", features = [
-  "library",
-] }
-schemars = "0.8.10"
-serde = { version = "1.0.140", default-features = false, features = ["derive"] }
+cosmwasm-schema = { workspace = true }
+cosmwasm-std    = { workspace = true }
+cw2             = { workspace = true }
+cw721           = { workspace = true }
+cw721-base      = { workspace = true, features = ["library"] }
+schemars        = { workspace = true }
+serde           = { workspace = true }

--- a/contracts/cw721-metadata-onchain/Cargo.toml
+++ b/contracts/cw721-metadata-onchain/Cargo.toml
@@ -12,12 +12,6 @@ repository    = { workspace = true }
 homepage      = { workspace = true }
 documentation = { workspace = true }
 
-exclude = [
-  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
-  "artifacts/*",
-]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/contracts/cw721-non-transferable/Cargo.toml
+++ b/contracts/cw721-non-transferable/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
-name = "cw721-non-transferable"
-authors = [
-  "Eliseo Cohen <eliseoci@users.noreply.github.com>",
-]
-version = "0.15.0"
-edition = "2021"
-description = "Non-transferable CW721 NFT example"
-license = "Apache-2.0"
+name          = "cw721-non-transferable"
+authors       = ["Eliseo Cohen <eliseoci@users.noreply.github.com>"]
+description   = "Non-transferable CW721 NFT example"
+version       = { workspace = true }
+edition       = { workspace = true }
+license       = { workspace = true }
+repository    = { workspace = true }
+homepage      = { workspace = true }
+documentation = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
@@ -18,21 +19,12 @@ backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
 
-[package.metadata.scripts]
-optimize = """docker run --rm -v "$(pwd)":/code \
-  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
-  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.6
-"""
-
 [dependencies]
-cosmwasm-schema = "1.1.0"
-cosmwasm-std = "1.1.0"
-cw-storage-plus = "0.15.0"
-cw2 = "0.15.0"
-cw721 = { path = "../../packages/cw721", version = "0.15.0" }
-cw721-base = { path = "../cw721-base", version = "0.15.0", features = [
-  "library",
-] }
-schemars = "0.8.10"
-serde = { version = "1.0.140", default-features = false, features = ["derive"] }
+cosmwasm-schema = { workspace = true }
+cosmwasm-std    = { workspace = true }
+cw-storage-plus = { workspace = true }
+cw2             = { workspace = true }
+cw721           = { workspace = true }
+cw721-base      = { workspace = true, features = ["library"] }
+schemars        = { workspace = true }
+serde           = { workspace = true }

--- a/contracts/cw721-non-transferable/Cargo.toml
+++ b/contracts/cw721-non-transferable/Cargo.toml
@@ -9,7 +9,6 @@ repository    = { workspace = true }
 homepage      = { workspace = true }
 documentation = { workspace = true }
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/packages/cw721/Cargo.toml
+++ b/packages/cw721/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
-name = "cw721"
-version = "0.15.0"
-authors = [
-    "Ethan Frey <ethanfrey@users.noreply.github.com>",
-    "Orkun Külçe <orkun@deuslabs.fi>",
+name          = "cw721"
+description   = "Definition and types for the CosmWasm-721 NFT interface"
+authors       = [
+  "Ethan Frey <ethanfrey@users.noreply.github.com>",
+  "Orkun Külçe <orkun@deuslabs.fi>",
 ]
-edition = "2021"
-description = "Definition and types for the CosmWasm-721 NFT interface"
-license = "Apache-2.0"
-repository = "https://github.com/CosmWasm/cw-nfts"
-homepage = "https://cosmwasm.com"
-documentation = "https://docs.cosmwasm.com"
+version       = { workspace = true }
+edition       = { workspace = true }
+license       = { workspace = true }
+repository    = { workspace = true }
+homepage      = { workspace = true }
+documentation = { workspace = true }
 
 [dependencies]
-cosmwasm-schema = "1.1.0"
-cosmwasm-std = "1.1.0"
-cw-utils = "0.15.0"
-schemars = "0.8.10"
-serde = { version = "1.0.140", default-features = false, features = ["derive"] }
+cosmwasm-schema = { workspace = true }
+cosmwasm-std    = { workspace = true }
+cw-utils        = { workspace = true }
+schemars        = { workspace = true }
+serde           = { workspace = true }


### PR DESCRIPTION
Use Rust 1.64's new [cargo workspace](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table) feature to manage package info and dependencies.

NOTES:
- Currently CI fails because there is a clippy warning, which is out-of-scope for this PR. This is fixed by #92 
- Since the workspace feature is only available at Rust >=1.64.0, adopting this change means all contributors to this repo must update their Rust installation to minimally 1.64.0
- The bash script `scripts/set_version.sh` is kinda useless after this PR