### PR TITLE
Replace the `cw721::CustomMsg` trait with `cosmwasm_std::CustomMsg`

### DIFF
--- a/contracts/cw2981-royalties/src/msg.rs
+++ b/contracts/cw2981-royalties/src/msg.rs
@@ -1,6 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::Uint128;
-use cw721::CustomMsg;
+use cosmwasm_std::{CustomMsg, Uint128};
 
 #[cw_serde]
 pub enum Cw2981QueryMsg {

--- a/contracts/cw721-base/src/execute.rs
+++ b/contracts/cw721-base/src/execute.rs
@@ -1,10 +1,10 @@
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
+use cosmwasm_std::{Binary, CustomMsg, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
 
 use cw2::set_contract_version;
-use cw721::{ContractInfoResponse, CustomMsg, Cw721Execute, Cw721ReceiveMsg, Expiration};
+use cw721::{ContractInfoResponse, Cw721Execute, Cw721ReceiveMsg, Expiration};
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, MintMsg};

--- a/contracts/cw721-base/src/query.rs
+++ b/contracts/cw721-base/src/query.rs
@@ -1,11 +1,13 @@
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use cosmwasm_std::{to_binary, Addr, Binary, BlockInfo, Deps, Env, Order, StdError, StdResult};
+use cosmwasm_std::{
+    to_binary, Addr, Binary, BlockInfo, CustomMsg, Deps, Env, Order, StdError, StdResult,
+};
 
 use cw721::{
-    AllNftInfoResponse, ApprovalResponse, ApprovalsResponse, ContractInfoResponse, CustomMsg,
-    Cw721Query, Expiration, NftInfoResponse, NumTokensResponse, OperatorsResponse, OwnerOfResponse,
+    AllNftInfoResponse, ApprovalResponse, ApprovalsResponse, ContractInfoResponse, Cw721Query,
+    Expiration, NftInfoResponse, NumTokensResponse, OperatorsResponse, OwnerOfResponse,
     TokensResponse,
 };
 use cw_storage_plus::Bound;

--- a/contracts/cw721-base/src/state.rs
+++ b/contracts/cw721-base/src/state.rs
@@ -3,9 +3,9 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
-use cosmwasm_std::{Addr, BlockInfo, StdResult, Storage};
+use cosmwasm_std::{Addr, BlockInfo, CustomMsg, StdResult, Storage};
 
-use cw721::{ContractInfoResponse, CustomMsg, Cw721, Expiration};
+use cw721::{ContractInfoResponse, Cw721, Expiration};
 use cw_storage_plus::{Index, IndexList, IndexedMap, Item, Map, MultiIndex};
 
 pub struct Cw721Contract<'a, T, C, E, Q>

--- a/packages/cw721/src/lib.rs
+++ b/packages/cw721/src/lib.rs
@@ -12,4 +12,4 @@ pub use crate::query::{
     TokensResponse,
 };
 pub use crate::receiver::Cw721ReceiveMsg;
-pub use crate::traits::{CustomMsg, Cw721, Cw721Execute, Cw721Query};
+pub use crate::traits::{Cw721, Cw721Execute, Cw721Query};

--- a/packages/cw721/src/traits.rs
+++ b/packages/cw721/src/traits.rs
@@ -1,4 +1,3 @@
-use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -7,13 +6,8 @@ use crate::{
     AllNftInfoResponse, ApprovalsResponse, ContractInfoResponse, NftInfoResponse,
     NumTokensResponse, OperatorsResponse, OwnerOfResponse, TokensResponse,
 };
-use cosmwasm_std::{Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdResult};
+use cosmwasm_std::{Binary, CustomMsg, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
 use cw_utils::Expiration;
-
-// TODO: move this somewhere else... ideally cosmwasm-std
-pub trait CustomMsg: Clone + std::fmt::Debug + PartialEq + JsonSchema {}
-
-impl CustomMsg for Empty {}
 
 pub trait Cw721<T, C>: Cw721Execute<T, C> + Cw721Query<T>
 where


### PR DESCRIPTION
In `packages/cw721/src/traits.rs` is this TODO item:

```rust
// TODO: move this somewhere else... ideally cosmwasm-std
pub trait CustomMsg: Clone + std::fmt::Debug + PartialEq + JsonSchema {}
```

In fact, `cosmwasm-std` already has the `CustomMsg` trait. This PR replaces `cw721::CustomMsg` trait with `cosmwasm_std::CustomMsg`.