### PR TITLE
Delete `MintMsg`

### DIFF
--- a/contracts/cw2981-royalties/schema/cw2981-royalties.json
+++ b/contracts/cw2981-royalties/schema/cw2981-royalties.json
@@ -212,7 +212,40 @@
         ],
         "properties": {
           "mint": {
-            "$ref": "#/definitions/MintMsg_for_Nullable_Metadata"
+            "type": "object",
+            "required": [
+              "owner",
+              "token_id"
+            ],
+            "properties": {
+              "extension": {
+                "description": "Any custom extension used by this contract",
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Metadata"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "owner": {
+                "description": "The owner of the newly minter NFT",
+                "type": "string"
+              },
+              "token_id": {
+                "description": "Unique ID of the NFT",
+                "type": "string"
+              },
+              "token_uri": {
+                "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
           }
         },
         "additionalProperties": false
@@ -389,42 +422,6 @@
             "minimum": 0.0
           },
           "youtube_url": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "MintMsg_for_Nullable_Metadata": {
-        "type": "object",
-        "required": [
-          "owner",
-          "token_id"
-        ],
-        "properties": {
-          "extension": {
-            "description": "Any custom extension used by this contract",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Metadata"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "owner": {
-            "description": "The owner of the newly minter NFT",
-            "type": "string"
-          },
-          "token_id": {
-            "description": "Unique ID of the NFT",
-            "type": "string"
-          },
-          "token_uri": {
-            "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
             "type": [
               "string",
               "null"

--- a/contracts/cw721-base/schema/cw721-base.json
+++ b/contracts/cw721-base/schema/cw721-base.json
@@ -212,7 +212,38 @@
         ],
         "properties": {
           "mint": {
-            "$ref": "#/definitions/MintMsg_for_Empty"
+            "type": "object",
+            "required": [
+              "extension",
+              "owner",
+              "token_id"
+            ],
+            "properties": {
+              "extension": {
+                "description": "Any custom extension used by this contract",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Empty"
+                  }
+                ]
+              },
+              "owner": {
+                "description": "The owner of the newly minter NFT",
+                "type": "string"
+              },
+              "token_id": {
+                "description": "Unique ID of the NFT",
+                "type": "string"
+              },
+              "token_uri": {
+                "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
           }
         },
         "additionalProperties": false
@@ -317,40 +348,6 @@
             "additionalProperties": false
           }
         ]
-      },
-      "MintMsg_for_Empty": {
-        "type": "object",
-        "required": [
-          "extension",
-          "owner",
-          "token_id"
-        ],
-        "properties": {
-          "extension": {
-            "description": "Any custom extension used by this contract",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Empty"
-              }
-            ]
-          },
-          "owner": {
-            "description": "The owner of the newly minter NFT",
-            "type": "string"
-          },
-          "token_id": {
-            "description": "Unique ID of the NFT",
-            "type": "string"
-          },
-          "token_uri": {
-            "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "additionalProperties": false
       },
       "Timestamp": {
         "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",

--- a/contracts/cw721-base/src/contract_tests.rs
+++ b/contracts/cw721-base/src/contract_tests.rs
@@ -7,9 +7,7 @@ use cw721::{
     NftInfoResponse, OperatorsResponse, OwnerOfResponse,
 };
 
-use crate::{
-    ContractError, Cw721Contract, ExecuteMsg, Extension, InstantiateMsg, MintMsg, QueryMsg,
-};
+use crate::{ContractError, Cw721Contract, ExecuteMsg, Extension, InstantiateMsg, QueryMsg};
 
 const MINTER: &str = "merlin";
 const CONTRACT_NAME: &str = "Magic Power";
@@ -74,12 +72,12 @@ fn minting() {
     let token_id = "petrify".to_string();
     let token_uri = "https://www.merriam-webster.com/dictionary/petrify".to_string();
 
-    let mint_msg = ExecuteMsg::Mint(MintMsg::<Extension> {
+    let mint_msg = ExecuteMsg::Mint {
         token_id: token_id.clone(),
         owner: String::from("medusa"),
         token_uri: Some(token_uri.clone()),
         extension: None,
-    });
+    };
 
     // random cannot mint
     let random = mock_info("random", &[]);
@@ -126,12 +124,12 @@ fn minting() {
     );
 
     // Cannot mint same token_id again
-    let mint_msg2 = ExecuteMsg::Mint(MintMsg::<Extension> {
+    let mint_msg2 = ExecuteMsg::Mint {
         token_id: token_id.clone(),
         owner: String::from("hercules"),
         token_uri: None,
         extension: None,
-    });
+    };
 
     let allowed = mock_info(MINTER, &[]);
     let err = contract
@@ -153,12 +151,12 @@ fn burning() {
     let token_id = "petrify".to_string();
     let token_uri = "https://www.merriam-webster.com/dictionary/petrify".to_string();
 
-    let mint_msg = ExecuteMsg::Mint(MintMsg::<Extension> {
+    let mint_msg = ExecuteMsg::Mint {
         token_id: token_id.clone(),
         owner: MINTER.to_string(),
         token_uri: Some(token_uri),
         extension: None,
-    });
+    };
 
     let burn_msg = ExecuteMsg::Burn { token_id };
 
@@ -203,12 +201,12 @@ fn transferring_nft() {
     let token_id = "melt".to_string();
     let token_uri = "https://www.merriam-webster.com/dictionary/melt".to_string();
 
-    let mint_msg = ExecuteMsg::Mint(MintMsg::<Extension> {
+    let mint_msg = ExecuteMsg::Mint {
         token_id: token_id.clone(),
         owner: String::from("venus"),
         token_uri: Some(token_uri),
         extension: None,
-    });
+    };
 
     let minter = mock_info(MINTER, &[]);
     contract
@@ -257,12 +255,12 @@ fn sending_nft() {
     let token_id = "melt".to_string();
     let token_uri = "https://www.merriam-webster.com/dictionary/melt".to_string();
 
-    let mint_msg = ExecuteMsg::Mint(MintMsg::<Extension> {
+    let mint_msg = ExecuteMsg::Mint {
         token_id: token_id.clone(),
         owner: String::from("venus"),
         token_uri: Some(token_uri),
         extension: None,
-    });
+    };
 
     let minter = mock_info(MINTER, &[]);
     contract
@@ -323,12 +321,12 @@ fn approving_revoking() {
     let token_id = "grow".to_string();
     let token_uri = "https://www.merriam-webster.com/dictionary/grow".to_string();
 
-    let mint_msg = ExecuteMsg::Mint(MintMsg::<Extension> {
+    let mint_msg = ExecuteMsg::Mint {
         token_id: token_id.clone(),
         owner: String::from("demeter"),
         token_uri: Some(token_uri),
         extension: None,
-    });
+    };
 
     let minter = mock_info(MINTER, &[]);
     contract
@@ -470,24 +468,24 @@ fn approving_all_revoking_all() {
     let token_id2 = "grow2".to_string();
     let token_uri2 = "https://www.merriam-webster.com/dictionary/grow2".to_string();
 
-    let mint_msg1 = ExecuteMsg::Mint(MintMsg::<Extension> {
+    let mint_msg1 = ExecuteMsg::Mint {
         token_id: token_id1.clone(),
         owner: String::from("demeter"),
         token_uri: Some(token_uri1),
         extension: None,
-    });
+    };
 
     let minter = mock_info(MINTER, &[]);
     contract
         .execute(deps.as_mut(), mock_env(), minter.clone(), mint_msg1)
         .unwrap();
 
-    let mint_msg2 = ExecuteMsg::Mint(MintMsg::<Extension> {
+    let mint_msg2 = ExecuteMsg::Mint {
         token_id: token_id2.clone(),
         owner: String::from("demeter"),
         token_uri: Some(token_uri2),
         extension: None,
-    });
+    };
 
     contract
         .execute(deps.as_mut(), mock_env(), minter, mint_msg2)
@@ -686,32 +684,32 @@ fn query_tokens_by_owner() {
     let ceres = String::from("ceres");
     let token_id3 = "sing".to_string();
 
-    let mint_msg = ExecuteMsg::Mint(MintMsg::<Extension> {
+    let mint_msg = ExecuteMsg::Mint {
         token_id: token_id1.clone(),
         owner: demeter.clone(),
         token_uri: None,
         extension: None,
-    });
+    };
     contract
         .execute(deps.as_mut(), mock_env(), minter.clone(), mint_msg)
         .unwrap();
 
-    let mint_msg = ExecuteMsg::Mint(MintMsg::<Extension> {
+    let mint_msg = ExecuteMsg::Mint {
         token_id: token_id2.clone(),
         owner: ceres.clone(),
         token_uri: None,
         extension: None,
-    });
+    };
     contract
         .execute(deps.as_mut(), mock_env(), minter.clone(), mint_msg)
         .unwrap();
 
-    let mint_msg = ExecuteMsg::Mint(MintMsg::<Extension> {
+    let mint_msg = ExecuteMsg::Mint {
         token_id: token_id3.clone(),
         owner: demeter.clone(),
         token_uri: None,
         extension: None,
-    });
+    };
     contract
         .execute(deps.as_mut(), mock_env(), minter, mint_msg)
         .unwrap();

--- a/contracts/cw721-base/src/lib.rs
+++ b/contracts/cw721-base/src/lib.rs
@@ -7,7 +7,7 @@ mod query;
 pub mod state;
 
 pub use crate::error::ContractError;
-pub use crate::msg::{ExecuteMsg, InstantiateMsg, MintMsg, MinterResponse, QueryMsg};
+pub use crate::msg::{ExecuteMsg, InstantiateMsg, MinterResponse, QueryMsg};
 pub use crate::state::Cw721Contract;
 use cosmwasm_std::Empty;
 

--- a/contracts/cw721-base/src/msg.rs
+++ b/contracts/cw721-base/src/msg.rs
@@ -49,27 +49,24 @@ pub enum ExecuteMsg<T, E> {
     RevokeAll { operator: String },
 
     /// Mint a new NFT, can only be called by the contract minter
-    Mint(MintMsg<T>),
+    Mint {
+        /// Unique ID of the NFT
+        token_id: String,
+        /// The owner of the newly minter NFT
+        owner: String,
+        /// Universal resource identifier for this NFT
+        /// Should point to a JSON file that conforms to the ERC721
+        /// Metadata JSON Schema
+        token_uri: Option<String>,
+        /// Any custom extension used by this contract
+        extension: T,
+    },
 
     /// Burn an NFT the sender has access to
     Burn { token_id: String },
 
     /// Extension msg
     Extension { msg: E },
-}
-
-#[cw_serde]
-pub struct MintMsg<T> {
-    /// Unique ID of the NFT
-    pub token_id: String,
-    /// The owner of the newly minter NFT
-    pub owner: String,
-    /// Universal resource identifier for this NFT
-    /// Should point to a JSON file that conforms to the ERC721
-    /// Metadata JSON Schema
-    pub token_uri: Option<String>,
-    /// Any custom extension used by this contract
-    pub extension: T,
 }
 
 #[cw_serde]

--- a/contracts/cw721-fixed-price/src/contract.rs
+++ b/contracts/cw721-fixed-price/src/contract.rs
@@ -13,7 +13,7 @@ use cw2::set_contract_version;
 use cw20::Cw20ReceiveMsg;
 use cw721_base::{
     helpers::Cw721Contract, msg::ExecuteMsg as Cw721ExecuteMsg,
-    msg::InstantiateMsg as Cw721InstantiateMsg, Extension, MintMsg,
+    msg::InstantiateMsg as Cw721InstantiateMsg,
 };
 use cw_utils::parse_reply_instantiate_data;
 
@@ -159,12 +159,12 @@ pub fn execute_receive(
         return Err(ContractError::WrongPaymentAmount {});
     }
 
-    let mint_msg = Cw721ExecuteMsg::<Extension, Empty>::Mint(MintMsg::<Extension> {
+    let mint_msg = Cw721ExecuteMsg::<_, Empty>::Mint {
         token_id: config.unused_token_id.to_string(),
         owner: sender,
         token_uri: config.token_uri.clone().into(),
         extension: config.extension.clone(),
-    });
+    };
 
     match config.cw721_address.clone() {
         Some(cw721) => {
@@ -184,6 +184,7 @@ mod tests {
     use super::*;
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info, MOCK_CONTRACT_ADDR};
     use cosmwasm_std::{from_binary, to_binary, CosmosMsg, SubMsgResponse, SubMsgResult};
+    use cw721_base::Extension;
     use prost::Message;
 
     const NFT_CONTRACT_ADDR: &str = "nftcontract";
@@ -371,12 +372,12 @@ mod tests {
         let info = mock_info(MOCK_CONTRACT_ADDR, &[]);
         let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
 
-        let mint_msg = Cw721ExecuteMsg::<Extension, Empty>::Mint(MintMsg::<Extension> {
+        let mint_msg = Cw721ExecuteMsg::<Extension, Empty>::Mint {
             token_id: String::from("0"),
             owner: String::from("minter"),
             token_uri: Some(String::from("https://ipfs.io/ipfs/Q")),
             extension: None,
-        });
+        };
 
         assert_eq!(
             res.messages[0],

--- a/contracts/cw721-metadata-onchain/schema/cw721-metadata-onchain.json
+++ b/contracts/cw721-metadata-onchain/schema/cw721-metadata-onchain.json
@@ -212,7 +212,40 @@
         ],
         "properties": {
           "mint": {
-            "$ref": "#/definitions/MintMsg_for_Nullable_Metadata"
+            "type": "object",
+            "required": [
+              "owner",
+              "token_id"
+            ],
+            "properties": {
+              "extension": {
+                "description": "Any custom extension used by this contract",
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Metadata"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "owner": {
+                "description": "The owner of the newly minter NFT",
+                "type": "string"
+              },
+              "token_id": {
+                "description": "Unique ID of the NFT",
+                "type": "string"
+              },
+              "token_uri": {
+                "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
           }
         },
         "additionalProperties": false
@@ -373,42 +406,6 @@
             ]
           },
           "youtube_url": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "MintMsg_for_Nullable_Metadata": {
-        "type": "object",
-        "required": [
-          "owner",
-          "token_id"
-        ],
-        "properties": {
-          "extension": {
-            "description": "Any custom extension used by this contract",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Metadata"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "owner": {
-            "description": "The owner of the newly minter NFT",
-            "type": "string"
-          },
-          "token_id": {
-            "description": "Unique ID of the NFT",
-            "type": "string"
-          },
-          "token_uri": {
-            "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
             "type": [
               "string",
               "null"

--- a/contracts/cw721-metadata-onchain/src/lib.rs
+++ b/contracts/cw721-metadata-onchain/src/lib.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::Empty;
 use cw2::set_contract_version;
-pub use cw721_base::{ContractError, InstantiateMsg, MintMsg, MinterResponse};
+pub use cw721_base::{ContractError, InstantiateMsg, MinterResponse};
 
 // Version info for migration
 const CONTRACT_NAME: &str = "crates.io:cw721-metadata-onchain";
@@ -98,23 +98,24 @@ mod tests {
             .unwrap();
 
         let token_id = "Enterprise";
-        let mint_msg = MintMsg {
+        let token_uri = Some("https://starships.example.com/Starship/Enterprise.json".into());
+        let extension = Some(Metadata {
+            description: Some("Spaceship with Warp Drive".into()),
+            name: Some("Starship USS Enterprise".to_string()),
+            ..Metadata::default()
+        });
+        let exec_msg = ExecuteMsg::Mint {
             token_id: token_id.to_string(),
             owner: "john".to_string(),
-            token_uri: Some("https://starships.example.com/Starship/Enterprise.json".into()),
-            extension: Some(Metadata {
-                description: Some("Spaceship with Warp Drive".into()),
-                name: Some("Starship USS Enterprise".to_string()),
-                ..Metadata::default()
-            }),
+            token_uri: token_uri.clone(),
+            extension: extension.clone(),
         };
-        let exec_msg = ExecuteMsg::Mint(mint_msg.clone());
         contract
             .execute(deps.as_mut(), mock_env(), info, exec_msg)
             .unwrap();
 
         let res = contract.nft_info(deps.as_ref(), token_id.into()).unwrap();
-        assert_eq!(res.token_uri, mint_msg.token_uri);
-        assert_eq!(res.extension, mint_msg.extension);
+        assert_eq!(res.token_uri, token_uri);
+        assert_eq!(res.extension, extension);
     }
 }

--- a/contracts/cw721-non-transferable/src/lib.rs
+++ b/contracts/cw721-non-transferable/src/lib.rs
@@ -3,7 +3,7 @@ use cosmwasm_std::Empty;
 pub use cw721_base::{
     entry::{execute as _execute, query as _query},
     ContractError, Cw721Contract, ExecuteMsg, Extension, InstantiateMsg as Cw721BaseInstantiateMsg,
-    MintMsg, MinterResponse,
+    MinterResponse,
 };
 
 pub mod msg;
@@ -79,9 +79,13 @@ pub mod entry {
                 }
             }
             None => match msg {
-                ExecuteMsg::Mint(msg) => {
-                    Cw721NonTransferableContract::default().mint(deps, env, info, msg)
-                }
+                ExecuteMsg::Mint {
+                    token_id,
+                    owner,
+                    token_uri,
+                    extension,
+                } => Cw721NonTransferableContract::default()
+                    .mint(deps, info, token_id, owner, token_uri, extension),
                 _ => Err(ContractError::Unauthorized {}),
             },
         }


### PR DESCRIPTION
Current:

```rust
enum ExecuteMsg<T> {
    Mint(MintMsg<T>),
}

struct MintMsg<T> {
    pub token_id: String,
    pub owner: String,
    pub token_uri: Option<String>,
    pub extension: T,
}
```

New:

```rust
enum ExecuteMsg {
    Mint {
        token_id: String,
        owner: String,
        token_uri: Option<String>,
        extension: T,
    },
}
```

This is backward compatible because `ExecuteMsg` serializes to the same JSON.