### PR TITLE
v0.17 upgrade logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ checksum = "c80e93d1deccb8588db03945016a292c3c631e6325d349ebb35d2db6f4f946f7"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2 1.0.1",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars",
  "semver",
  "serde",
@@ -328,6 +328,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw2"
+version = "1.0.1"
+source = "git+https://github.com/mars-protocol/cw-plus?rev=1a3a944#1a3a944b64cf6e9fcfada48f2b09aaa1a90aef74"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 1.0.1",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "cw20"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,7 +359,7 @@ version = "0.17.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2 1.0.1",
+ "cw2 1.0.1 (git+https://github.com/mars-protocol/cw-plus?rev=1a3a944)",
  "cw721 0.17.0",
  "cw721-base 0.17.0",
  "schemars",
@@ -404,7 +417,7 @@ dependencies = [
  "cw-ownable",
  "cw-storage-plus 1.0.1",
  "cw-utils 1.0.1",
- "cw2 1.0.1",
+ "cw2 1.0.1 (git+https://github.com/mars-protocol/cw-plus?rev=1a3a944)",
  "cw721 0.17.0",
  "cw721-base 0.16.0",
  "schemars",
@@ -420,7 +433,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.0.1",
  "cw-utils 1.0.1",
- "cw2 1.0.1",
+ "cw2 1.0.1 (git+https://github.com/mars-protocol/cw-plus?rev=1a3a944)",
  "cw20",
  "cw721-base 0.17.0",
  "prost 0.10.4",
@@ -435,7 +448,7 @@ version = "0.17.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2 1.0.1",
+ "cw2 1.0.1 (git+https://github.com/mars-protocol/cw-plus?rev=1a3a944)",
  "cw721 0.17.0",
  "cw721-base 0.17.0",
  "schemars",
@@ -449,7 +462,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
+ "cw2 1.0.1 (git+https://github.com/mars-protocol/cw-plus?rev=1a3a944)",
  "cw721 0.17.0",
  "cw721-base 0.17.0",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ rust-version  = "1.65"
 [workspace.dependencies]
 cosmwasm-schema = "1.2.1"
 cosmwasm-std    = "1.2.1"
-cw2             = "1.0.1"
+# FIXME: change back to the "official" crates.io release after this PR is merged:
+# https://github.com/CosmWasm/cw-plus/pull/858
+cw2             = { git = "https://github.com/mars-protocol/cw-plus", rev = "1a3a944" }
 cw20            = "1.0.1"
 cw721           = { version = "0.17.0", path = "./packages/cw721" }
 cw721-base      = { version = "0.17.0", path = "./contracts/cw721-base" }

--- a/contracts/cw721-base/src/error.rs
+++ b/contracts/cw721-base/src/error.rs
@@ -10,6 +10,9 @@ pub enum ContractError {
     #[error(transparent)]
     Ownership(#[from] OwnershipError),
 
+    #[error(transparent)]
+    Version(#[from] cw2::VersionError),
+
     #[error("token_id already claimed")]
     Claimed {},
 
@@ -18,7 +21,4 @@ pub enum ContractError {
 
     #[error("Approval not found for: {spender}")]
     ApprovalNotFound { spender: String },
-
-    #[error("found version ({0}) while attempting to migrate from 0.16.0")]
-    WrongMigrateVersion(String),
 }

--- a/contracts/cw721-base/src/execute.rs
+++ b/contracts/cw721-base/src/execute.rs
@@ -4,14 +4,11 @@ use serde::Serialize;
 
 use cosmwasm_std::{Binary, CustomMsg, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
 
-use cw2::{get_contract_version, set_contract_version, ContractVersion};
 use cw721::{ContractInfoResponse, Cw721Execute, Cw721ReceiveMsg, Expiration};
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg};
 use crate::state::{Approval, Cw721Contract, TokenInfo};
-use crate::upgrades;
-use crate::{CONTRACT_NAME, CONTRACT_VERSION};
 
 impl<'a, T, C, E, Q> Cw721Contract<'a, T, C, E, Q>
 where
@@ -129,19 +126,6 @@ where
     ) -> Result<Response<C>, ContractError> {
         let ownership = cw_ownable::update_ownership(deps, &env.block, &info.sender, action)?;
         Ok(Response::new().add_attributes(ownership.into_attributes()))
-    }
-
-    /// Migrates the contract from the previous version to the current
-    /// version.
-    pub fn migrate(deps: DepsMut, _env: Env) -> Result<Response<C>, ContractError> {
-        let ContractVersion { version, .. } = get_contract_version(deps.storage)?;
-        set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-        if version != "0.16.0" {
-            Err(ContractError::WrongMigrateVersion(version))
-        } else {
-            upgrades::v0_16::migrate::<T, C, E, Q>(deps)
-        }
     }
 }
 

--- a/contracts/cw721-base/src/lib.rs
+++ b/contracts/cw721-base/src/lib.rs
@@ -32,6 +32,12 @@ pub type Extension = Option<Empty>;
 pub const CONTRACT_NAME: &str = "crates.io:cw721-base";
 pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+// currently we only support migrating from 0.16.0. this is ok for now because
+// we have not released any 0.16.x where x != 0
+//
+// TODO: parse semvar so that any version 0.16.x can be migrated from
+pub const EXPECTED_FROM_VERSION: &str = "0.16.0";
+
 pub mod entry {
     use super::*;
 
@@ -71,8 +77,16 @@ pub mod entry {
     }
 
     #[cfg_attr(not(feature = "library"), entry_point)]
-    pub fn migrate(deps: DepsMut, env: Env, _msg: Empty) -> Result<Response, ContractError> {
-        Cw721Contract::<Extension, Empty, Empty, Empty>::migrate(deps, env)
+    pub fn migrate(deps: DepsMut, _env: Env, _msg: Empty) -> Result<Response, ContractError> {
+        // make sure the correct contract is being upgraded, and it's being
+        // upgraded from the correct version.
+        cw2::assert_contract_version(deps.as_ref().storage, CONTRACT_NAME, EXPECTED_FROM_VERSION)?;
+
+        // update contract version
+        cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+        // perform the upgrade
+        upgrades::v0_17::migrate::<Extension, Empty, Empty, Empty>(deps)
     }
 }
 

--- a/contracts/cw721-base/src/upgrades/mod.rs
+++ b/contracts/cw721-base/src/upgrades/mod.rs
@@ -1,1 +1,1 @@
-pub mod v0_16;
+pub mod v0_17;

--- a/contracts/cw721-base/src/upgrades/v0_17.rs
+++ b/contracts/cw721-base/src/upgrades/v0_17.rs
@@ -10,10 +10,14 @@ where
     Q: CustomMsg,
     E: CustomMsg,
 {
+    // remove old minter info
     let tract16 = v16::Cw721Contract::<T, C, E, Q>::default();
     let minter = tract16.minter.load(deps.storage)?;
     tract16.minter.remove(deps.storage);
+
+    // save new ownership info
     let ownership = cw_ownable::initialize_owner(deps.storage, deps.api, Some(minter.as_str()))?;
+
     Ok(Response::new()
         .add_attribute("action", "migrate")
         .add_attribute("from_version", "0.16.0")


### PR DESCRIPTION
- Rename `upgrades/v0_16.rs` to `upgrades/v0_17.rs` (I think the filename should be the version being migrated **to**, not the version being migrated **from**)
- Version check to make sure that correct contract is being migrated and it's being migrated from the correct version (using `cw2::assert_contract_version`; have to use our fork of cw2 before [our PR](https://github.com/CosmWasm/cw-plus/pull/858) is merged)