### PR TITLE
Make upgrade logics public

### DIFF
--- a/contracts/cw721-base/src/lib.rs
+++ b/contracts/cw721-base/src/lib.rs
@@ -4,7 +4,7 @@ pub mod helpers;
 pub mod msg;
 mod query;
 pub mod state;
-mod upgrades;
+pub mod upgrades;
 
 #[cfg(test)]
 mod contract_tests;


### PR DESCRIPTION
Currently `cw721_base::upgrades` is not exported, but it should be. It is needed by custom NFT contracts that extends cw721-base to implement their custom migration logics.

Let's consider a contract called sg721-base that extends cw721-base. Also assume:

- sg721-base 0.25 uses cw721-base 0.16
- sg721-base 0.26 uses cw721-base 0.17

How should sg721-base implement its 0.25 => 0.26 migration? Imo, the cleanest way is this:

```rust
const CONTRACT_NAME: &str = "crates.io:sg721-base";
const FROM_VERSION: &str = "0.25.0";
const TO_VERSION: &str = "0.26.0"

pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> StdResult<Response> {
    // check the correct contract is being upgraded,
    // and it's being migrated from the correct version
    cw2::assert_contract_version(deps.as_ref(), CONTRACT_NAME, FROM_VERSION)?;

    // update contract version info
    cw2::set_contract_version(deps, CONTRACT_NAME, TO_VERSION)?;

    // run the base contract's migration logics
    cw721_base::upgrades::v0_17::migrate(deps)?;

    // other custom migration logics specific to sg721...
}
```

This is somewhat similar to how inheritance works in Python:

```python
Class Cw721Base:
    def migrate(self, deps):
        # base contract migration logics...

Class Sg721Base(Cw721Base):
    def migrate(self, deps):
        # run base contract migration logics:
        __super__().migrate(deps)

        # other custom migration logics specific to sg721...
```

See how the child contract needs to invoke `cw721_base::upgrades::v0_17::migrate` similar to how the python class invokes its parent's method by `__super__`.

Similarly, if a contract extends sg721-base, then it should also invoke `sg721_base::upgrades::v0_26::migrate` in its custom migration method.