### PR TITLE
new features: setting and removing withdraw addresses by owner, allowing withdrawing funds by any to given address

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -21,6 +21,7 @@ command = "cargo"
 args    = ["build", "--release", "--locked", "--target", "wasm32-unknown-unknown"]
 
 [tasks.optimize]
+# https://hub.docker.com/r/cosmwasm/workspace-optimizer/tags https://hub.docker.com/r/cosmwasm/workspace-optimizer-arm64/tags
 script = """
 if [[ $(arch) == "arm64" ]]; then
   image="cosmwasm/workspace-optimizer-arm64"
@@ -31,7 +32,7 @@ fi
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  ${image}:0.12.13
+  ${image}:0.15.0
 """
 
 [tasks.schema]

--- a/contracts/cw2981-royalties/schema/cw2981-royalties.json
+++ b/contracts/cw2981-royalties/schema/cw2981-royalties.json
@@ -23,6 +23,12 @@
       "symbol": {
         "description": "Symbol of the NFT contract",
         "type": "string"
+      },
+      "withdraw_address": {
+        "type": [
+          "string",
+          "null"
+        ]
       }
     },
     "additionalProperties": false
@@ -295,6 +301,64 @@
         "additionalProperties": false
       },
       {
+        "description": "Sets address to send withdrawn fees to. Only owner can call this.",
+        "type": "object",
+        "required": [
+          "set_withdraw_address"
+        ],
+        "properties": {
+          "set_withdraw_address": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Removes the withdraw address, so fees are sent to the contract. Only owner can call this.",
+        "type": "object",
+        "required": [
+          "remove_withdraw_address"
+        ],
+        "properties": {
+          "remove_withdraw_address": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Withdraw from the contract to the given address. Anyone can call this, which is okay since withdraw address has been set by owner.",
+        "type": "object",
+        "required": [
+          "withdraw_funds"
+        ],
+        "properties": {
+          "withdraw_funds": {
+            "type": "object",
+            "required": [
+              "amount"
+            ],
+            "properties": {
+              "amount": {
+                "$ref": "#/definitions/Coin"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
         "required": [
@@ -363,6 +427,21 @@
       "Binary": {
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
+      },
+      "Coin": {
+        "type": "object",
+        "required": [
+          "amount",
+          "denom"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          },
+          "denom": {
+            "type": "string"
+          }
+        }
       },
       "Empty": {
         "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
@@ -523,6 +602,10 @@
           }
         },
         "additionalProperties": false
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
       },
       "Uint64": {
         "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
@@ -874,6 +957,19 @@
                 "$ref": "#/definitions/Cw2981QueryMsg"
               }
             },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_withdraw_address"
+        ],
+        "properties": {
+          "get_withdraw_address": {
+            "type": "object",
             "additionalProperties": false
           }
         },
@@ -1489,6 +1585,11 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Null",
       "type": "null"
+    },
+    "get_withdraw_address": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "String",
+      "type": "string"
     },
     "minter": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/cw2981-royalties/src/lib.rs
+++ b/contracts/cw2981-royalties/src/lib.rs
@@ -66,10 +66,10 @@ pub mod entry {
         env: Env,
         info: MessageInfo,
         msg: InstantiateMsg,
-    ) -> StdResult<Response> {
+    ) -> Result<Response, ContractError> {
         cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
-        Cw2981Contract::default().instantiate(deps.branch(), env, info, msg)
+        Ok(Cw2981Contract::default().instantiate(deps.branch(), env, info, msg)?)
     }
 
     #[entry_point]
@@ -137,6 +137,7 @@ mod tests {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
             minter: CREATOR.to_string(),
+            withdraw_address: None,
         };
         entry::instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg).unwrap();
 
@@ -170,6 +171,7 @@ mod tests {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
             minter: CREATOR.to_string(),
+            withdraw_address: None,
         };
         entry::instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg).unwrap();
 
@@ -200,6 +202,7 @@ mod tests {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
             minter: CREATOR.to_string(),
+            withdraw_address: None,
         };
         entry::instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg).unwrap();
 
@@ -240,6 +243,7 @@ mod tests {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
             minter: CREATOR.to_string(),
+            withdraw_address: None,
         };
         entry::instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg).unwrap();
 

--- a/contracts/cw721-base/schema/cw721-base.json
+++ b/contracts/cw721-base/schema/cw721-base.json
@@ -23,6 +23,12 @@
       "symbol": {
         "description": "Symbol of the NFT contract",
         "type": "string"
+      },
+      "withdraw_address": {
+        "type": [
+          "string",
+          "null"
+        ]
       }
     },
     "additionalProperties": false
@@ -293,6 +299,64 @@
         "additionalProperties": false
       },
       {
+        "description": "Sets address to send withdrawn fees to. Only owner can call this.",
+        "type": "object",
+        "required": [
+          "set_withdraw_address"
+        ],
+        "properties": {
+          "set_withdraw_address": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Removes the withdraw address, so fees are sent to the contract. Only owner can call this.",
+        "type": "object",
+        "required": [
+          "remove_withdraw_address"
+        ],
+        "properties": {
+          "remove_withdraw_address": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Withdraw from the contract to the given address. Anyone can call this, which is okay since withdraw address has been set by owner.",
+        "type": "object",
+        "required": [
+          "withdraw_funds"
+        ],
+        "properties": {
+          "withdraw_funds": {
+            "type": "object",
+            "required": [
+              "amount"
+            ],
+            "properties": {
+              "amount": {
+                "$ref": "#/definitions/Coin"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
         "required": [
@@ -362,6 +426,21 @@
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
       },
+      "Coin": {
+        "type": "object",
+        "required": [
+          "amount",
+          "denom"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          },
+          "denom": {
+            "type": "string"
+          }
+        }
+      },
       "Empty": {
         "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "object"
@@ -420,6 +499,10 @@
             "$ref": "#/definitions/Uint64"
           }
         ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
       },
       "Uint64": {
         "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
@@ -771,6 +854,19 @@
                 "$ref": "#/definitions/Empty"
               }
             },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_withdraw_address"
+        ],
+        "properties": {
+          "get_withdraw_address": {
+            "type": "object",
             "additionalProperties": false
           }
         },
@@ -1298,6 +1394,11 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Null",
       "type": "null"
+    },
+    "get_withdraw_address": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "String",
+      "type": "string"
     },
     "minter": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/cw721-base/src/error.rs
+++ b/contracts/cw721-base/src/error.rs
@@ -21,4 +21,7 @@ pub enum ContractError {
 
     #[error("Approval not found for: {spender}")]
     ApprovalNotFound { spender: String },
+
+    #[error("No withdraw address set")]
+    NoWithdrawAddress {},
 }

--- a/contracts/cw721-base/src/execute.rs
+++ b/contracts/cw721-base/src/execute.rs
@@ -2,7 +2,9 @@ use cw_ownable::OwnershipError;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use cosmwasm_std::{Binary, CustomMsg, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
+use cosmwasm_std::{
+    Addr, BankMsg, Binary, Coin, CustomMsg, Deps, DepsMut, Env, MessageInfo, Response, Storage,
+};
 
 use cw721::{ContractInfoResponse, Cw721Execute, Cw721ReceiveMsg, Expiration};
 
@@ -23,14 +25,19 @@ where
         _env: Env,
         _info: MessageInfo,
         msg: InstantiateMsg,
-    ) -> StdResult<Response<C>> {
-        let info = ContractInfoResponse {
+    ) -> Result<Response<C>, ContractError> {
+        let contract_info = ContractInfoResponse {
             name: msg.name,
             symbol: msg.symbol,
         };
-        self.contract_info.save(deps.storage, &info)?;
+        self.contract_info.save(deps.storage, &contract_info)?;
 
         cw_ownable::initialize_owner(deps.storage, deps.api, Some(&msg.minter))?;
+
+        if let Some(address) = msg.withdraw_address {
+            let owner = deps.api.addr_validate(&msg.minter)?;
+            self.set_withdraw_address(deps, &owner, address)?;
+        }
 
         Ok(Response::default())
     }
@@ -73,6 +80,13 @@ where
             ExecuteMsg::Burn { token_id } => self.burn(deps, env, info, token_id),
             ExecuteMsg::UpdateOwnership(action) => Self::update_ownership(deps, env, info, action),
             ExecuteMsg::Extension { msg: _ } => Ok(Response::default()),
+            ExecuteMsg::SetWithdrawAddress { address } => {
+                self.set_withdraw_address(deps, &info.sender, address)
+            }
+            ExecuteMsg::RemoveWithdrawAddress {} => {
+                self.remove_withdraw_address(deps.storage, &info.sender)
+            }
+            ExecuteMsg::WithdrawFunds { amount } => self.withdraw_funds(deps.storage, &amount),
         }
     }
 }
@@ -126,6 +140,60 @@ where
     ) -> Result<Response<C>, ContractError> {
         let ownership = cw_ownable::update_ownership(deps, &env.block, &info.sender, action)?;
         Ok(Response::new().add_attributes(ownership.into_attributes()))
+    }
+
+    pub fn set_withdraw_address(
+        &self,
+        deps: DepsMut,
+        sender: &Addr,
+        address: String,
+    ) -> Result<Response<C>, ContractError> {
+        cw_ownable::assert_owner(deps.storage, sender)?;
+        deps.api.addr_validate(&address)?;
+        self.withdraw_address.save(deps.storage, &address)?;
+        Ok(Response::new()
+            .add_attribute("action", "set_withdraw_address")
+            .add_attribute("address", address))
+    }
+
+    pub fn remove_withdraw_address(
+        &self,
+        storage: &mut dyn Storage,
+        sender: &Addr,
+    ) -> Result<Response<C>, ContractError> {
+        cw_ownable::assert_owner(storage, sender)?;
+        let address = self.withdraw_address.may_load(storage)?;
+        match address {
+            Some(address) => {
+                self.withdraw_address.remove(storage);
+                Ok(Response::new()
+                    .add_attribute("action", "remove_withdraw_address")
+                    .add_attribute("address", address))
+            }
+            None => Err(ContractError::NoWithdrawAddress {}),
+        }
+    }
+
+    pub fn withdraw_funds(
+        &self,
+        storage: &mut dyn Storage,
+        amount: &Coin,
+    ) -> Result<Response<C>, ContractError> {
+        let address = self.withdraw_address.may_load(storage)?;
+        match address {
+            Some(address) => {
+                let msg = BankMsg::Send {
+                    to_address: address.clone(),
+                    amount: vec![amount.clone()],
+                };
+                Ok(Response::new()
+                    .add_message(msg)
+                    .add_attribute("action", "withdraw_funds")
+                    .add_attribute("amount", amount.amount.to_string())
+                    .add_attribute("denom", amount.denom.to_string()))
+            }
+            None => Err(ContractError::NoWithdrawAddress {}),
+        }
     }
 }
 

--- a/contracts/cw721-base/src/execute.rs
+++ b/contracts/cw721-base/src/execute.rs
@@ -183,7 +183,7 @@ where
         match address {
             Some(address) => {
                 let msg = BankMsg::Send {
-                    to_address: address.clone(),
+                    to_address: address,
                     amount: vec![amount.clone()],
                 };
                 Ok(Response::new()

--- a/contracts/cw721-base/src/lib.rs
+++ b/contracts/cw721-base/src/lib.rs
@@ -52,7 +52,7 @@ pub mod entry {
         env: Env,
         info: MessageInfo,
         msg: InstantiateMsg,
-    ) -> StdResult<Response> {
+    ) -> Result<Response, ContractError> {
         cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
         let tract = Cw721Contract::<Extension, Empty, Empty, Empty>::default();
@@ -110,6 +110,7 @@ mod tests {
                 name: "".into(),
                 symbol: "".into(),
                 minter: "larry".into(),
+                withdraw_address: None,
             },
         )
         .unwrap();

--- a/contracts/cw721-base/src/msg.rs
+++ b/contracts/cw721-base/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::Binary;
+use cosmwasm_std::{Binary, Coin};
 use cw721::Expiration;
 use cw_ownable::{cw_ownable_execute, cw_ownable_query};
 use schemars::JsonSchema;
@@ -15,6 +15,8 @@ pub struct InstantiateMsg {
     /// This is designed for a base NFT that is controlled by an external program
     /// or contract. You will likely replace this with custom logic in custom NFTs
     pub minter: String,
+
+    pub withdraw_address: Option<String>,
 }
 
 /// This is like Cw721ExecuteMsg but we add a Mint command for an owner
@@ -69,6 +71,14 @@ pub enum ExecuteMsg<T, E> {
 
     /// Extension msg
     Extension { msg: E },
+
+    /// Sets address to send withdrawn fees to. Only owner can call this.
+    SetWithdrawAddress { address: String },
+    /// Removes the withdraw address, so fees are sent to the contract. Only owner can call this.
+    RemoveWithdrawAddress {},
+    /// Withdraw from the contract to the given address. Anyone can call this,
+    /// which is okay since withdraw address has been set by owner.
+    WithdrawFunds { amount: Coin },
 }
 
 #[cw_ownable_query]
@@ -157,6 +167,9 @@ pub enum QueryMsg<Q: JsonSchema> {
     /// Extension query
     #[returns(())]
     Extension { msg: Q },
+
+    #[returns(String)]
+    GetWithdrawAddress {},
 }
 
 /// Shows who can mint these tokens

--- a/contracts/cw721-base/src/query.rs
+++ b/contracts/cw721-base/src/query.rs
@@ -326,6 +326,9 @@ where
             )?),
             QueryMsg::Ownership {} => to_json_binary(&Self::ownership(deps)?),
             QueryMsg::Extension { msg: _ } => Ok(Binary::default()),
+            QueryMsg::GetWithdrawAddress {} => {
+                to_json_binary(&self.withdraw_address.may_load(deps.storage)?)
+            }
         }
     }
 

--- a/contracts/cw721-base/src/state.rs
+++ b/contracts/cw721-base/src/state.rs
@@ -19,6 +19,7 @@ where
     /// Stored as (granter, operator) giving operator full control over granter's account
     pub operators: Map<'a, (&'a Addr, &'a Addr), Expiration>,
     pub tokens: IndexedMap<'a, &'a str, TokenInfo<T>, TokenIndexes<'a, T>>,
+    pub withdraw_address: Item<'a, String>,
 
     pub(crate) _custom_response: PhantomData<C>,
     pub(crate) _custom_query: PhantomData<Q>,
@@ -48,6 +49,7 @@ where
             "operators",
             "tokens",
             "tokens__owner",
+            "withdraw_address",
         )
     }
 }
@@ -64,6 +66,7 @@ where
         operator_key: &'a str,
         tokens_key: &'a str,
         tokens_owner_key: &'a str,
+        withdraw_address_key: &'a str,
     ) -> Self {
         let indexes = TokenIndexes {
             owner: MultiIndex::new(token_owner_idx, tokens_key, tokens_owner_key),
@@ -73,6 +76,7 @@ where
             token_count: Item::new(token_count_key),
             operators: Map::new(operator_key),
             tokens: IndexedMap::new(tokens_key, indexes),
+            withdraw_address: Item::new(withdraw_address_key),
             _custom_response: PhantomData,
             _custom_execute: PhantomData,
             _custom_query: PhantomData,

--- a/contracts/cw721-expiration/schema/cw721-expiration.json
+++ b/contracts/cw721-expiration/schema/cw721-expiration.json
@@ -30,6 +30,12 @@
       "symbol": {
         "description": "Symbol of the NFT contract",
         "type": "string"
+      },
+      "withdraw_address": {
+        "type": [
+          "string",
+          "null"
+        ]
       }
     },
     "additionalProperties": false
@@ -302,6 +308,64 @@
         "additionalProperties": false
       },
       {
+        "description": "Sets address to send withdrawn fees to. Only owner can call this.",
+        "type": "object",
+        "required": [
+          "set_withdraw_address"
+        ],
+        "properties": {
+          "set_withdraw_address": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Removes the withdraw address, so fees are sent to the contract. Only owner can call this.",
+        "type": "object",
+        "required": [
+          "remove_withdraw_address"
+        ],
+        "properties": {
+          "remove_withdraw_address": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Withdraw from the contract to the given address. Anyone can call this, which is okay since withdraw address has been set by owner.",
+        "type": "object",
+        "required": [
+          "withdraw_funds"
+        ],
+        "properties": {
+          "withdraw_funds": {
+            "type": "object",
+            "required": [
+              "amount"
+            ],
+            "properties": {
+              "amount": {
+                "$ref": "#/definitions/Coin"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
         "required": [
@@ -371,6 +435,21 @@
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
       },
+      "Coin": {
+        "type": "object",
+        "required": [
+          "amount",
+          "denom"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          },
+          "denom": {
+            "type": "string"
+          }
+        }
+      },
       "Empty": {
         "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "object"
@@ -429,6 +508,10 @@
             "$ref": "#/definitions/Uint64"
           }
         ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
       },
       "Uint64": {
         "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",

--- a/contracts/cw721-expiration/src/contract_tests.rs
+++ b/contracts/cw721-expiration/src/contract_tests.rs
@@ -30,6 +30,7 @@ fn setup_contract(deps: DepsMut<'_>, expiration_days: u16) -> Cw721ExpirationCon
         name: CONTRACT_NAME.to_string(),
         symbol: SYMBOL.to_string(),
         minter: String::from(MINTER),
+        withdraw_address: None,
     };
     let info = mock_info("creator", &[]);
     let res = contract.instantiate(deps, mock_env(), info, msg).unwrap();
@@ -47,6 +48,7 @@ fn proper_instantiation() {
         name: CONTRACT_NAME.to_string(),
         symbol: SYMBOL.to_string(),
         minter: String::from(MINTER),
+        withdraw_address: None,
     };
     let info = mock_info("creator", &[]);
 

--- a/contracts/cw721-expiration/src/lib.rs
+++ b/contracts/cw721-expiration/src/lib.rs
@@ -87,6 +87,7 @@ mod tests {
                 name: "".into(),
                 symbol: "".into(),
                 minter: "mrt".into(),
+                withdraw_address: None,
             },
         )
         .unwrap_err();
@@ -102,6 +103,7 @@ mod tests {
                 name: "".into(),
                 symbol: "".into(),
                 minter: "mrt".into(),
+                withdraw_address: None,
             },
         )
         .unwrap();

--- a/contracts/cw721-expiration/src/msg.rs
+++ b/contracts/cw721-expiration/src/msg.rs
@@ -19,6 +19,8 @@ pub struct InstantiateMsg {
     /// This is designed for a base NFT that is controlled by an external program
     /// or contract. You will likely replace this with custom logic in custom NFTs
     pub minter: String,
+
+    pub withdraw_address: Option<String>,
 }
 
 #[cw_ownable_query]

--- a/contracts/cw721-fixed-price/src/contract.rs
+++ b/contracts/cw721-fixed-price/src/contract.rs
@@ -62,6 +62,7 @@ pub fn instantiate(
                 name: msg.name.clone(),
                 symbol: msg.symbol,
                 minter: env.contract.address.to_string(),
+                withdraw_address: None,
             })?,
             funds: vec![],
             admin: None,
@@ -227,6 +228,7 @@ mod tests {
                         name: msg.name.clone(),
                         symbol: msg.symbol.clone(),
                         minter: MOCK_CONTRACT_ADDR.to_string(),
+                        withdraw_address: None,
                     })
                     .unwrap(),
                     funds: vec![],

--- a/contracts/cw721-metadata-onchain/schema/cw721-metadata-onchain.json
+++ b/contracts/cw721-metadata-onchain/schema/cw721-metadata-onchain.json
@@ -23,6 +23,12 @@
       "symbol": {
         "description": "Symbol of the NFT contract",
         "type": "string"
+      },
+      "withdraw_address": {
+        "type": [
+          "string",
+          "null"
+        ]
       }
     },
     "additionalProperties": false
@@ -295,6 +301,64 @@
         "additionalProperties": false
       },
       {
+        "description": "Sets address to send withdrawn fees to. Only owner can call this.",
+        "type": "object",
+        "required": [
+          "set_withdraw_address"
+        ],
+        "properties": {
+          "set_withdraw_address": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Removes the withdraw address, so fees are sent to the contract. Only owner can call this.",
+        "type": "object",
+        "required": [
+          "remove_withdraw_address"
+        ],
+        "properties": {
+          "remove_withdraw_address": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Withdraw from the contract to the given address. Anyone can call this, which is okay since withdraw address has been set by owner.",
+        "type": "object",
+        "required": [
+          "withdraw_funds"
+        ],
+        "properties": {
+          "withdraw_funds": {
+            "type": "object",
+            "required": [
+              "amount"
+            ],
+            "properties": {
+              "amount": {
+                "$ref": "#/definitions/Coin"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
         "required": [
@@ -363,6 +427,21 @@
       "Binary": {
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
+      },
+      "Coin": {
+        "type": "object",
+        "required": [
+          "amount",
+          "denom"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          },
+          "denom": {
+            "type": "string"
+          }
+        }
       },
       "Empty": {
         "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
@@ -507,6 +586,10 @@
           }
         },
         "additionalProperties": false
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
       },
       "Uint64": {
         "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
@@ -858,6 +941,19 @@
                 "$ref": "#/definitions/Empty"
               }
             },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_withdraw_address"
+        ],
+        "properties": {
+          "get_withdraw_address": {
+            "type": "object",
             "additionalProperties": false
           }
         },
@@ -1385,6 +1481,11 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Null",
       "type": "null"
+    },
+    "get_withdraw_address": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "String",
+      "type": "string"
     },
     "minter": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/cw721-metadata-onchain/src/lib.rs
+++ b/contracts/cw721-metadata-onchain/src/lib.rs
@@ -48,7 +48,7 @@ pub mod entry {
         env: Env,
         info: MessageInfo,
         msg: InstantiateMsg,
-    ) -> StdResult<Response> {
+    ) -> Result<Response, ContractError> {
         cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
         Cw721MetadataContract::default().instantiate(deps.branch(), env, info, msg)
@@ -93,6 +93,7 @@ mod tests {
                 name: "".into(),
                 symbol: "".into(),
                 minter: "larry".into(),
+                withdraw_address: None,
             },
         )
         .unwrap();
@@ -112,6 +113,7 @@ mod tests {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
             minter: CREATOR.to_string(),
+            withdraw_address: None,
         };
         contract
             .instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg)

--- a/contracts/cw721-non-transferable/src/lib.rs
+++ b/contracts/cw721-non-transferable/src/lib.rs
@@ -47,6 +47,7 @@ pub mod entry {
             name: msg.name,
             symbol: msg.symbol,
             minter: msg.minter,
+            withdraw_address: None,
         };
 
         Cw721NonTransferableContract::default().instantiate(


### PR DESCRIPTION
New feature allowing cw721 withdrawing funds. This is e.g. needed for fee share module: https://docs.junonetwork.io/developer-guides/juno-modules/feeshare#registering-factory-contracts

Note: fee share is just an example. In general it allows cw721 holding funds and being able to withdraw. Like royalties and mint funds may be stored here.
also withdraw address is optional - so owner can opt to set a withdrawal address or not.

Added these new messages to cw721-base:

ExecuteMsg

```rs
    /// Sets address to send withdrawn fees to. Only owner can call this.
    SetWithdrawAddress { address: String },
    /// Removes the withdraw address, so fees are sent to the contract. Only owner can call this.
    RemoveWithdrawAddress {},
    /// Withdraw from the contract to the given address. Anyone can call this,
    /// which is okay since withdraw address has been set by owner.
    WithdrawFunds { amount: Coin },
```

QueryMsg:

```rs
    #[returns(String)]
    GetWithdrawAddress {},
```

@shanev @JakeHartnell 