### PR TITLE
feature: optional withdrawal address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "c9d19de80eff169429ac1e9f48fffb163916b448a44e8e046186232046d9e1f9"
 
 [[package]]
 name = "base16ct"
@@ -33,9 +33,9 @@ checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "base64ct"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bech32"
@@ -54,30 +54,30 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "bnum"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128a44527fc0d6abf05f9eda748b9027536e12dff93f5acc8449f51583309350"
+checksum = "ab9008b6bb9fc80b5277f2fe481c09e828743d9151203e804583eb4c9e15b31d"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cfg-if"
@@ -87,9 +87,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cosmwasm-crypto"
@@ -111,7 +111,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea73e9162e6efde00018d55ed0061e93a108b5d6ec4548b4f8ce3c706249687"
 dependencies = [
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -135,7 +135,7 @@ checksum = "43609e92ce1b9368aa951b334dd354a2d0dd4d484931a5f83ae10e12a26c8ba9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -162,18 +162,18 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561604d987be2ef3e34db1f01f0c98544106d84d8be2af92c0737bb199af452c"
+checksum = "67fff029689ae89127cf6d7655809a68d712f3edbdb9686c70b018ba438b26ca"
 dependencies = [
  "anyhow",
  "bech32",
@@ -256,7 +256,7 @@ checksum = "a1d3bf2e0f341bb6cc100d7d441d31cf713fbd3ce0c511f91e79f14b40a889af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "cw20"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011c45920f8200bd5d32d4fe52502506f64f2f75651ab408054d4cfc75ca3a9b"
+checksum = "526e39bb20534e25a1cd0386727f0038f4da294e5e535729ba3ef54055246abd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -504,7 +504,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -522,7 +522,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer 0.10.4",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -530,15 +530,15 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.10"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
+checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
  "digest 0.10.7",
@@ -565,15 +565,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.6"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97ca172ae9dc9f9b779a6e3a65d308f2af74e5b8c921299075bdb4a0370e914"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -606,9 +606,9 @@ checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "libc",
@@ -690,15 +690,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "k256"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
+checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -710,15 +710,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
@@ -738,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
 dependencies = [
  "unicode-ident",
 ]
@@ -775,7 +775,7 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -788,7 +788,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -827,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "schemars"
@@ -852,14 +852,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "sec1"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
@@ -886,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15bee9b04dd165c3f4e142628982ddde884c2022a89e8ddf99c4829bf2c3a58"
+checksum = "16a62a1fad1e1828b24acac8f2b468971dade7b8c3c2e672bcadefefb1f8c137"
 dependencies = [
  "serde",
 ]
@@ -901,7 +901,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -912,14 +912,14 @@ checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -952,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
@@ -962,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
@@ -978,15 +978,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -995,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1006,35 +1006,35 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "83a48fd946b02c0a526b2e9481c8e2a17755e47039164a86c4070446e3a4614d"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "e7fbe9b594d6568a6a1443250a7e67d80b74e1e96f6d1715e1e21cc1888291d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.43",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "version_check"
@@ -1050,6 +1050,6 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,20 +11,20 @@ documentation = "https://docs.cosmwasm.com"
 rust-version  = "1.65"
 
 [workspace.dependencies]
-cosmwasm-schema = "1.2.1"
-cosmwasm-std    = "1.2.1"
-cw2             = "1.1.0"
-cw20            = "1.1.0"
-cw721           = { version = "0.18.0", path = "./packages/cw721" }
-cw721-base      = { version = "0.18.0", path = "./contracts/cw721-base" }
+cosmwasm-schema = "^1.2"
+cosmwasm-std    = "^1.2"
+cw2             = "^1.1"
+cw20            = "^1.1"
+cw721           = { version = "*", path = "./packages/cw721" }
+cw721-base      = { version = "*", path = "./contracts/cw721-base" }
 cw721-base-016  = { version = "0.16.0", package = "cw721-base" }
-cw-multi-test   = "0.19"
-cw-ownable      = "0.5.1"
-cw-storage-plus = "1.1.0"
-cw-utils        = "1.0.1"
-schemars        = "0.8.11"
+cw-multi-test   = "^0.20"
+cw-ownable      = "^0.5"
+cw-storage-plus = "^1.1"
+cw-utils        = "^1.0"
+schemars        = "^0.8"
 serde           = { version = "1.0.152", default-features = false, features = ["derive"] }
-thiserror       = "1.0.38"
+thiserror       = "^1.0"
 
 [profile.release.package.cw721-base]
 codegen-units = 1

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -21,6 +21,7 @@ command = "cargo"
 args    = ["build", "--release", "--locked", "--target", "wasm32-unknown-unknown"]
 
 [tasks.optimize]
+# https://hub.docker.com/r/cosmwasm/workspace-optimizer/tags https://hub.docker.com/r/cosmwasm/workspace-optimizer-arm64/tags
 script = """
 if [[ $(arch) == "arm64" ]]; then
   image="cosmwasm/workspace-optimizer-arm64"
@@ -31,7 +32,7 @@ fi
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  ${image}:0.12.13
+  ${image}:0.15.0
 """
 
 [tasks.schema]

--- a/contracts/cw2981-royalties/schema/cw2981-royalties.json
+++ b/contracts/cw2981-royalties/schema/cw2981-royalties.json
@@ -1588,8 +1588,11 @@
     },
     "get_withdraw_address": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "String",
-      "type": "string"
+      "title": "Nullable_String",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "minter": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/cw2981-royalties/schema/cw2981-royalties.json
+++ b/contracts/cw2981-royalties/schema/cw2981-royalties.json
@@ -23,6 +23,12 @@
       "symbol": {
         "description": "Symbol of the NFT contract",
         "type": "string"
+      },
+      "withdraw_address": {
+        "type": [
+          "string",
+          "null"
+        ]
       }
     },
     "additionalProperties": false
@@ -295,6 +301,64 @@
         "additionalProperties": false
       },
       {
+        "description": "Sets address to send withdrawn fees to. Only owner can call this.",
+        "type": "object",
+        "required": [
+          "set_withdraw_address"
+        ],
+        "properties": {
+          "set_withdraw_address": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Removes the withdraw address, so fees are sent to the contract. Only owner can call this.",
+        "type": "object",
+        "required": [
+          "remove_withdraw_address"
+        ],
+        "properties": {
+          "remove_withdraw_address": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Withdraw from the contract to the given address. Anyone can call this, which is okay since withdraw address has been set by owner.",
+        "type": "object",
+        "required": [
+          "withdraw_funds"
+        ],
+        "properties": {
+          "withdraw_funds": {
+            "type": "object",
+            "required": [
+              "amount"
+            ],
+            "properties": {
+              "amount": {
+                "$ref": "#/definitions/Coin"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
         "required": [
@@ -363,6 +427,21 @@
       "Binary": {
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
+      },
+      "Coin": {
+        "type": "object",
+        "required": [
+          "amount",
+          "denom"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          },
+          "denom": {
+            "type": "string"
+          }
+        }
       },
       "Empty": {
         "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
@@ -523,6 +602,10 @@
           }
         },
         "additionalProperties": false
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
       },
       "Uint64": {
         "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
@@ -874,6 +957,19 @@
                 "$ref": "#/definitions/Cw2981QueryMsg"
               }
             },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_withdraw_address"
+        ],
+        "properties": {
+          "get_withdraw_address": {
+            "type": "object",
             "additionalProperties": false
           }
         },
@@ -1489,6 +1585,11 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Null",
       "type": "null"
+    },
+    "get_withdraw_address": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "String",
+      "type": "string"
     },
     "minter": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/cw2981-royalties/src/lib.rs
+++ b/contracts/cw2981-royalties/src/lib.rs
@@ -66,10 +66,10 @@ pub mod entry {
         env: Env,
         info: MessageInfo,
         msg: InstantiateMsg,
-    ) -> StdResult<Response> {
+    ) -> Result<Response, ContractError> {
         cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
-        Cw2981Contract::default().instantiate(deps.branch(), env, info, msg)
+        Ok(Cw2981Contract::default().instantiate(deps.branch(), env, info, msg)?)
     }
 
     #[entry_point]
@@ -137,6 +137,7 @@ mod tests {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
             minter: CREATOR.to_string(),
+            withdraw_address: None,
         };
         entry::instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg).unwrap();
 
@@ -170,6 +171,7 @@ mod tests {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
             minter: CREATOR.to_string(),
+            withdraw_address: None,
         };
         entry::instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg).unwrap();
 
@@ -200,6 +202,7 @@ mod tests {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
             minter: CREATOR.to_string(),
+            withdraw_address: None,
         };
         entry::instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg).unwrap();
 
@@ -240,6 +243,7 @@ mod tests {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
             minter: CREATOR.to_string(),
+            withdraw_address: None,
         };
         entry::instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg).unwrap();
 

--- a/contracts/cw721-base/schema/cw721-base.json
+++ b/contracts/cw721-base/schema/cw721-base.json
@@ -23,6 +23,12 @@
       "symbol": {
         "description": "Symbol of the NFT contract",
         "type": "string"
+      },
+      "withdraw_address": {
+        "type": [
+          "string",
+          "null"
+        ]
       }
     },
     "additionalProperties": false
@@ -293,6 +299,64 @@
         "additionalProperties": false
       },
       {
+        "description": "Sets address to send withdrawn fees to. Only owner can call this.",
+        "type": "object",
+        "required": [
+          "set_withdraw_address"
+        ],
+        "properties": {
+          "set_withdraw_address": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Removes the withdraw address, so fees are sent to the contract. Only owner can call this.",
+        "type": "object",
+        "required": [
+          "remove_withdraw_address"
+        ],
+        "properties": {
+          "remove_withdraw_address": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Withdraw from the contract to the given address. Anyone can call this, which is okay since withdraw address has been set by owner.",
+        "type": "object",
+        "required": [
+          "withdraw_funds"
+        ],
+        "properties": {
+          "withdraw_funds": {
+            "type": "object",
+            "required": [
+              "amount"
+            ],
+            "properties": {
+              "amount": {
+                "$ref": "#/definitions/Coin"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
         "required": [
@@ -362,6 +426,21 @@
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
       },
+      "Coin": {
+        "type": "object",
+        "required": [
+          "amount",
+          "denom"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          },
+          "denom": {
+            "type": "string"
+          }
+        }
+      },
       "Empty": {
         "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "object"
@@ -420,6 +499,10 @@
             "$ref": "#/definitions/Uint64"
           }
         ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
       },
       "Uint64": {
         "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
@@ -771,6 +854,19 @@
                 "$ref": "#/definitions/Empty"
               }
             },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_withdraw_address"
+        ],
+        "properties": {
+          "get_withdraw_address": {
+            "type": "object",
             "additionalProperties": false
           }
         },
@@ -1298,6 +1394,11 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Null",
       "type": "null"
+    },
+    "get_withdraw_address": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "String",
+      "type": "string"
     },
     "minter": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/cw721-base/schema/cw721-base.json
+++ b/contracts/cw721-base/schema/cw721-base.json
@@ -1397,8 +1397,11 @@
     },
     "get_withdraw_address": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "String",
-      "type": "string"
+      "title": "Nullable_String",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "minter": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/cw721-base/src/error.rs
+++ b/contracts/cw721-base/src/error.rs
@@ -21,4 +21,7 @@ pub enum ContractError {
 
     #[error("Approval not found for: {spender}")]
     ApprovalNotFound { spender: String },
+
+    #[error("No withdraw address set")]
+    NoWithdrawAddress {},
 }

--- a/contracts/cw721-base/src/execute.rs
+++ b/contracts/cw721-base/src/execute.rs
@@ -2,7 +2,9 @@ use cw_ownable::OwnershipError;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use cosmwasm_std::{Binary, CustomMsg, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
+use cosmwasm_std::{
+    Addr, BankMsg, Binary, Coin, CustomMsg, Deps, DepsMut, Env, MessageInfo, Response, Storage,
+};
 
 use cw721::{ContractInfoResponse, Cw721Execute, Cw721ReceiveMsg, Expiration};
 
@@ -23,14 +25,19 @@ where
         _env: Env,
         _info: MessageInfo,
         msg: InstantiateMsg,
-    ) -> StdResult<Response<C>> {
-        let info = ContractInfoResponse {
+    ) -> Result<Response<C>, ContractError> {
+        let contract_info = ContractInfoResponse {
             name: msg.name,
             symbol: msg.symbol,
         };
-        self.contract_info.save(deps.storage, &info)?;
+        self.contract_info.save(deps.storage, &contract_info)?;
 
         cw_ownable::initialize_owner(deps.storage, deps.api, Some(&msg.minter))?;
+
+        if let Some(address) = msg.withdraw_address {
+            let owner = deps.api.addr_validate(&msg.minter)?;
+            self.set_withdraw_address(deps, &owner, address)?;
+        }
 
         Ok(Response::default())
     }
@@ -73,6 +80,13 @@ where
             ExecuteMsg::Burn { token_id } => self.burn(deps, env, info, token_id),
             ExecuteMsg::UpdateOwnership(action) => Self::update_ownership(deps, env, info, action),
             ExecuteMsg::Extension { msg: _ } => Ok(Response::default()),
+            ExecuteMsg::SetWithdrawAddress { address } => {
+                self.set_withdraw_address(deps, &info.sender, address)
+            }
+            ExecuteMsg::RemoveWithdrawAddress {} => {
+                self.remove_withdraw_address(deps.storage, &info.sender)
+            }
+            ExecuteMsg::WithdrawFunds { amount } => self.withdraw_funds(deps.storage, &amount),
         }
     }
 }
@@ -126,6 +140,60 @@ where
     ) -> Result<Response<C>, ContractError> {
         let ownership = cw_ownable::update_ownership(deps, &env.block, &info.sender, action)?;
         Ok(Response::new().add_attributes(ownership.into_attributes()))
+    }
+
+    pub fn set_withdraw_address(
+        &self,
+        deps: DepsMut,
+        sender: &Addr,
+        address: String,
+    ) -> Result<Response<C>, ContractError> {
+        cw_ownable::assert_owner(deps.storage, sender)?;
+        deps.api.addr_validate(&address)?;
+        self.withdraw_address.save(deps.storage, &address)?;
+        Ok(Response::new()
+            .add_attribute("action", "set_withdraw_address")
+            .add_attribute("address", address))
+    }
+
+    pub fn remove_withdraw_address(
+        &self,
+        storage: &mut dyn Storage,
+        sender: &Addr,
+    ) -> Result<Response<C>, ContractError> {
+        cw_ownable::assert_owner(storage, sender)?;
+        let address = self.withdraw_address.may_load(storage)?;
+        match address {
+            Some(address) => {
+                self.withdraw_address.remove(storage);
+                Ok(Response::new()
+                    .add_attribute("action", "remove_withdraw_address")
+                    .add_attribute("address", address))
+            }
+            None => Err(ContractError::NoWithdrawAddress {}),
+        }
+    }
+
+    pub fn withdraw_funds(
+        &self,
+        storage: &mut dyn Storage,
+        amount: &Coin,
+    ) -> Result<Response<C>, ContractError> {
+        let address = self.withdraw_address.may_load(storage)?;
+        match address {
+            Some(address) => {
+                let msg = BankMsg::Send {
+                    to_address: address.clone(),
+                    amount: vec![amount.clone()],
+                };
+                Ok(Response::new()
+                    .add_message(msg)
+                    .add_attribute("action", "withdraw_funds")
+                    .add_attribute("amount", amount.amount.to_string())
+                    .add_attribute("denom", amount.denom.to_string()))
+            }
+            None => Err(ContractError::NoWithdrawAddress {}),
+        }
     }
 }
 

--- a/contracts/cw721-base/src/execute.rs
+++ b/contracts/cw721-base/src/execute.rs
@@ -183,7 +183,7 @@ where
         match address {
             Some(address) => {
                 let msg = BankMsg::Send {
-                    to_address: address.clone(),
+                    to_address: address,
                     amount: vec![amount.clone()],
                 };
                 Ok(Response::new()

--- a/contracts/cw721-base/src/lib.rs
+++ b/contracts/cw721-base/src/lib.rs
@@ -52,7 +52,7 @@ pub mod entry {
         env: Env,
         info: MessageInfo,
         msg: InstantiateMsg,
-    ) -> StdResult<Response> {
+    ) -> Result<Response, ContractError> {
         cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
         let tract = Cw721Contract::<Extension, Empty, Empty, Empty>::default();
@@ -110,6 +110,7 @@ mod tests {
                 name: "".into(),
                 symbol: "".into(),
                 minter: "larry".into(),
+                withdraw_address: None,
             },
         )
         .unwrap();

--- a/contracts/cw721-base/src/msg.rs
+++ b/contracts/cw721-base/src/msg.rs
@@ -168,7 +168,7 @@ pub enum QueryMsg<Q: JsonSchema> {
     #[returns(())]
     Extension { msg: Q },
 
-    #[returns(String)]
+    #[returns(Option<String>)]
     GetWithdrawAddress {},
 }
 

--- a/contracts/cw721-base/src/msg.rs
+++ b/contracts/cw721-base/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::Binary;
+use cosmwasm_std::{Binary, Coin};
 use cw721::Expiration;
 use cw_ownable::{cw_ownable_execute, cw_ownable_query};
 use schemars::JsonSchema;
@@ -15,6 +15,8 @@ pub struct InstantiateMsg {
     /// This is designed for a base NFT that is controlled by an external program
     /// or contract. You will likely replace this with custom logic in custom NFTs
     pub minter: String,
+
+    pub withdraw_address: Option<String>,
 }
 
 /// This is like Cw721ExecuteMsg but we add a Mint command for an owner
@@ -69,6 +71,14 @@ pub enum ExecuteMsg<T, E> {
 
     /// Extension msg
     Extension { msg: E },
+
+    /// Sets address to send withdrawn fees to. Only owner can call this.
+    SetWithdrawAddress { address: String },
+    /// Removes the withdraw address, so fees are sent to the contract. Only owner can call this.
+    RemoveWithdrawAddress {},
+    /// Withdraw from the contract to the given address. Anyone can call this,
+    /// which is okay since withdraw address has been set by owner.
+    WithdrawFunds { amount: Coin },
 }
 
 #[cw_ownable_query]
@@ -157,6 +167,9 @@ pub enum QueryMsg<Q: JsonSchema> {
     /// Extension query
     #[returns(())]
     Extension { msg: Q },
+
+    #[returns(String)]
+    GetWithdrawAddress {},
 }
 
 /// Shows who can mint these tokens

--- a/contracts/cw721-base/src/multi_tests.rs
+++ b/contracts/cw721-base/src/multi_tests.rs
@@ -4,7 +4,7 @@ use cw_multi_test::{App, Contract, ContractWrapper, Executor};
 
 use crate::MinterResponse;
 
-fn cw721_base_contract() -> Box<dyn Contract<Empty>> {
+fn cw721_base_latest_contract() -> Box<dyn Contract<Empty>> {
     let contract = ContractWrapper::new(
         crate::entry::execute,
         crate::entry::instantiate,
@@ -80,13 +80,13 @@ fn mint_transfer_and_burn(app: &mut App, cw721: Addr, sender: Addr, token_id: St
 /// Instantiates a 0.16 version of this contract and tests that tokens
 /// can be minted, transferred, and burnred after migration.
 #[test]
-fn test_016_017_migration() {
+fn test_migration_016_to_latest() {
     use cw721_base_016 as v16;
     let mut app = App::default();
     let admin = || Addr::unchecked("admin");
 
     let code_id_016 = app.store_code(cw721_base_016_contract());
-    let code_id_017 = app.store_code(cw721_base_contract());
+    let code_id_latest = app.store_code(cw721_base_latest_contract());
 
     let cw721 = app
         .instantiate_contract(
@@ -109,7 +109,7 @@ fn test_016_017_migration() {
         admin(),
         WasmMsg::Migrate {
             contract_addr: cw721.to_string(),
-            new_code_id: code_id_017,
+            new_code_id: code_id_latest,
             msg: to_json_binary(&Empty::default()).unwrap(),
         }
         .into(),

--- a/contracts/cw721-base/src/multi_tests.rs
+++ b/contracts/cw721-base/src/multi_tests.rs
@@ -133,3 +133,36 @@ fn test_migration_016_to_latest() {
         .unwrap();
     assert_eq!(m.minter, admin().to_string());
 }
+
+/// Test backward compatibility using instantiate msg from a 0.16 version on latest contract.
+/// This ensures existing 3rd party contracts doesnt need to updated as well.
+#[test]
+fn test_instantiate_016_msg() {
+    use cw721_base_016 as v16;
+    let mut app = App::default();
+    let admin = || Addr::unchecked("admin");
+
+    let code_id_latest = app.store_code(cw721_base_latest_contract());
+
+    let cw721 = app
+        .instantiate_contract(
+            code_id_latest,
+            admin(),
+            &v16::InstantiateMsg {
+                name: "collection".to_string(),
+                symbol: "symbol".to_string(),
+                minter: admin().into_string(),
+            },
+            &[],
+            "cw721-base",
+            Some(admin().into_string()),
+        )
+        .unwrap();
+
+    // assert withdraw address is None
+    let withdraw_addr: Option<String> = app
+        .wrap()
+        .query_wasm_smart(cw721, &crate::QueryMsg::<Empty>::GetWithdrawAddress {})
+        .unwrap();
+    assert!(withdraw_addr.is_none());
+}

--- a/contracts/cw721-base/src/query.rs
+++ b/contracts/cw721-base/src/query.rs
@@ -326,6 +326,9 @@ where
             )?),
             QueryMsg::Ownership {} => to_json_binary(&Self::ownership(deps)?),
             QueryMsg::Extension { msg: _ } => Ok(Binary::default()),
+            QueryMsg::GetWithdrawAddress {} => {
+                to_json_binary(&self.withdraw_address.may_load(deps.storage)?)
+            }
         }
     }
 

--- a/contracts/cw721-base/src/state.rs
+++ b/contracts/cw721-base/src/state.rs
@@ -19,6 +19,7 @@ where
     /// Stored as (granter, operator) giving operator full control over granter's account
     pub operators: Map<'a, (&'a Addr, &'a Addr), Expiration>,
     pub tokens: IndexedMap<'a, &'a str, TokenInfo<T>, TokenIndexes<'a, T>>,
+    pub withdraw_address: Item<'a, String>,
 
     pub(crate) _custom_response: PhantomData<C>,
     pub(crate) _custom_query: PhantomData<Q>,
@@ -48,6 +49,7 @@ where
             "operators",
             "tokens",
             "tokens__owner",
+            "withdraw_address",
         )
     }
 }
@@ -64,6 +66,7 @@ where
         operator_key: &'a str,
         tokens_key: &'a str,
         tokens_owner_key: &'a str,
+        withdraw_address_key: &'a str,
     ) -> Self {
         let indexes = TokenIndexes {
             owner: MultiIndex::new(token_owner_idx, tokens_key, tokens_owner_key),
@@ -73,6 +76,7 @@ where
             token_count: Item::new(token_count_key),
             operators: Map::new(operator_key),
             tokens: IndexedMap::new(tokens_key, indexes),
+            withdraw_address: Item::new(withdraw_address_key),
             _custom_response: PhantomData,
             _custom_execute: PhantomData,
             _custom_query: PhantomData,

--- a/contracts/cw721-expiration/schema/cw721-expiration.json
+++ b/contracts/cw721-expiration/schema/cw721-expiration.json
@@ -30,6 +30,12 @@
       "symbol": {
         "description": "Symbol of the NFT contract",
         "type": "string"
+      },
+      "withdraw_address": {
+        "type": [
+          "string",
+          "null"
+        ]
       }
     },
     "additionalProperties": false
@@ -302,6 +308,64 @@
         "additionalProperties": false
       },
       {
+        "description": "Sets address to send withdrawn fees to. Only owner can call this.",
+        "type": "object",
+        "required": [
+          "set_withdraw_address"
+        ],
+        "properties": {
+          "set_withdraw_address": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Removes the withdraw address, so fees are sent to the contract. Only owner can call this.",
+        "type": "object",
+        "required": [
+          "remove_withdraw_address"
+        ],
+        "properties": {
+          "remove_withdraw_address": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Withdraw from the contract to the given address. Anyone can call this, which is okay since withdraw address has been set by owner.",
+        "type": "object",
+        "required": [
+          "withdraw_funds"
+        ],
+        "properties": {
+          "withdraw_funds": {
+            "type": "object",
+            "required": [
+              "amount"
+            ],
+            "properties": {
+              "amount": {
+                "$ref": "#/definitions/Coin"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
         "required": [
@@ -371,6 +435,21 @@
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
       },
+      "Coin": {
+        "type": "object",
+        "required": [
+          "amount",
+          "denom"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          },
+          "denom": {
+            "type": "string"
+          }
+        }
+      },
       "Empty": {
         "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "object"
@@ -429,6 +508,10 @@
             "$ref": "#/definitions/Uint64"
           }
         ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
       },
       "Uint64": {
         "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",

--- a/contracts/cw721-expiration/src/contract_tests.rs
+++ b/contracts/cw721-expiration/src/contract_tests.rs
@@ -30,6 +30,7 @@ fn setup_contract(deps: DepsMut<'_>, expiration_days: u16) -> Cw721ExpirationCon
         name: CONTRACT_NAME.to_string(),
         symbol: SYMBOL.to_string(),
         minter: String::from(MINTER),
+        withdraw_address: None,
     };
     let info = mock_info("creator", &[]);
     let res = contract.instantiate(deps, mock_env(), info, msg).unwrap();
@@ -47,6 +48,7 @@ fn proper_instantiation() {
         name: CONTRACT_NAME.to_string(),
         symbol: SYMBOL.to_string(),
         minter: String::from(MINTER),
+        withdraw_address: None,
     };
     let info = mock_info("creator", &[]);
 

--- a/contracts/cw721-expiration/src/lib.rs
+++ b/contracts/cw721-expiration/src/lib.rs
@@ -87,6 +87,7 @@ mod tests {
                 name: "".into(),
                 symbol: "".into(),
                 minter: "mrt".into(),
+                withdraw_address: None,
             },
         )
         .unwrap_err();
@@ -102,6 +103,7 @@ mod tests {
                 name: "".into(),
                 symbol: "".into(),
                 minter: "mrt".into(),
+                withdraw_address: None,
             },
         )
         .unwrap();

--- a/contracts/cw721-expiration/src/msg.rs
+++ b/contracts/cw721-expiration/src/msg.rs
@@ -19,6 +19,8 @@ pub struct InstantiateMsg {
     /// This is designed for a base NFT that is controlled by an external program
     /// or contract. You will likely replace this with custom logic in custom NFTs
     pub minter: String,
+
+    pub withdraw_address: Option<String>,
 }
 
 #[cw_ownable_query]

--- a/contracts/cw721-fixed-price/schema/cw721-fixed-price.json
+++ b/contracts/cw721-fixed-price/schema/cw721-fixed-price.json
@@ -54,6 +54,12 @@
       },
       "unit_price": {
         "$ref": "#/definitions/Uint128"
+      },
+      "withdraw_address": {
+        "type": [
+          "string",
+          "null"
+        ]
       }
     },
     "additionalProperties": false,

--- a/contracts/cw721-fixed-price/src/contract.rs
+++ b/contracts/cw721-fixed-price/src/contract.rs
@@ -62,7 +62,7 @@ pub fn instantiate(
                 name: msg.name.clone(),
                 symbol: msg.symbol,
                 minter: env.contract.address.to_string(),
-                withdraw_address: None,
+                withdraw_address: msg.withdraw_address,
             })?,
             funds: vec![],
             admin: None,
@@ -212,6 +212,7 @@ mod tests {
             cw20_address: Addr::unchecked(MOCK_CONTRACT_ADDR),
             token_uri: String::from("https://ipfs.io/ipfs/Q"),
             extension: None,
+            withdraw_address: None,
         };
 
         let info = mock_info("owner", &[]);
@@ -294,6 +295,7 @@ mod tests {
             cw20_address: Addr::unchecked(MOCK_CONTRACT_ADDR),
             token_uri: String::from("https://ipfs.io/ipfs/Q"),
             extension: None,
+            withdraw_address: None,
         };
 
         let info = mock_info("owner", &[]);
@@ -318,6 +320,7 @@ mod tests {
             cw20_address: Addr::unchecked(MOCK_CONTRACT_ADDR),
             token_uri: String::from("https://ipfs.io/ipfs/Q"),
             extension: None,
+            withdraw_address: None,
         };
 
         let info = mock_info("owner", &[]);
@@ -342,6 +345,7 @@ mod tests {
             cw20_address: Addr::unchecked(MOCK_CONTRACT_ADDR),
             token_uri: String::from("https://ipfs.io/ipfs/Q"),
             extension: None,
+            withdraw_address: None,
         };
 
         let info = mock_info("owner", &[]);
@@ -409,6 +413,7 @@ mod tests {
             cw20_address: Addr::unchecked(MOCK_CONTRACT_ADDR),
             token_uri: String::from("https://ipfs.io/ipfs/Q"),
             extension: None,
+            withdraw_address: None,
         };
 
         let info = mock_info("owner", &[]);
@@ -450,6 +455,7 @@ mod tests {
             cw20_address: Addr::unchecked(MOCK_CONTRACT_ADDR),
             token_uri: String::from("https://ipfs.io/ipfs/Q"),
             extension: None,
+            withdraw_address: None,
         };
 
         let info = mock_info("owner", &[]);
@@ -493,6 +499,7 @@ mod tests {
             cw20_address: Addr::unchecked(MOCK_CONTRACT_ADDR),
             token_uri: String::from("https://ipfs.io/ipfs/Q"),
             extension: None,
+            withdraw_address: None,
         };
 
         let info = mock_info("owner", &[]);
@@ -547,6 +554,7 @@ mod tests {
             cw20_address: Addr::unchecked(MOCK_CONTRACT_ADDR),
             token_uri: String::from("https://ipfs.io/ipfs/Q"),
             extension: None,
+            withdraw_address: None,
         };
 
         let info = mock_info("owner", &[]);
@@ -581,6 +589,7 @@ mod tests {
             cw20_address: Addr::unchecked(MOCK_CONTRACT_ADDR),
             token_uri: String::from("https://ipfs.io/ipfs/Q"),
             extension: None,
+            withdraw_address: None,
         };
 
         let info = mock_info("owner", &[]);
@@ -635,6 +644,7 @@ mod tests {
             cw20_address: Addr::unchecked(MOCK_CONTRACT_ADDR),
             token_uri: String::from("https://ipfs.io/ipfs/Q"),
             extension: None,
+            withdraw_address: None,
         };
 
         let info = mock_info("owner", &[]);

--- a/contracts/cw721-fixed-price/src/contract.rs
+++ b/contracts/cw721-fixed-price/src/contract.rs
@@ -62,6 +62,7 @@ pub fn instantiate(
                 name: msg.name.clone(),
                 symbol: msg.symbol,
                 minter: env.contract.address.to_string(),
+                withdraw_address: None,
             })?,
             funds: vec![],
             admin: None,
@@ -227,6 +228,7 @@ mod tests {
                         name: msg.name.clone(),
                         symbol: msg.symbol.clone(),
                         minter: MOCK_CONTRACT_ADDR.to_string(),
+                        withdraw_address: None,
                     })
                     .unwrap(),
                     funds: vec![],

--- a/contracts/cw721-fixed-price/src/msg.rs
+++ b/contracts/cw721-fixed-price/src/msg.rs
@@ -14,6 +14,7 @@ pub struct InstantiateMsg {
     pub cw20_address: Addr,
     pub token_uri: String,
     pub extension: Extension,
+    pub withdraw_address: Option<String>,
 }
 
 #[cw_serde]

--- a/contracts/cw721-metadata-onchain/schema/cw721-metadata-onchain.json
+++ b/contracts/cw721-metadata-onchain/schema/cw721-metadata-onchain.json
@@ -1484,8 +1484,11 @@
     },
     "get_withdraw_address": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "String",
-      "type": "string"
+      "title": "Nullable_String",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "minter": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/cw721-metadata-onchain/schema/cw721-metadata-onchain.json
+++ b/contracts/cw721-metadata-onchain/schema/cw721-metadata-onchain.json
@@ -23,6 +23,12 @@
       "symbol": {
         "description": "Symbol of the NFT contract",
         "type": "string"
+      },
+      "withdraw_address": {
+        "type": [
+          "string",
+          "null"
+        ]
       }
     },
     "additionalProperties": false
@@ -295,6 +301,64 @@
         "additionalProperties": false
       },
       {
+        "description": "Sets address to send withdrawn fees to. Only owner can call this.",
+        "type": "object",
+        "required": [
+          "set_withdraw_address"
+        ],
+        "properties": {
+          "set_withdraw_address": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Removes the withdraw address, so fees are sent to the contract. Only owner can call this.",
+        "type": "object",
+        "required": [
+          "remove_withdraw_address"
+        ],
+        "properties": {
+          "remove_withdraw_address": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Withdraw from the contract to the given address. Anyone can call this, which is okay since withdraw address has been set by owner.",
+        "type": "object",
+        "required": [
+          "withdraw_funds"
+        ],
+        "properties": {
+          "withdraw_funds": {
+            "type": "object",
+            "required": [
+              "amount"
+            ],
+            "properties": {
+              "amount": {
+                "$ref": "#/definitions/Coin"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
         "required": [
@@ -363,6 +427,21 @@
       "Binary": {
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
+      },
+      "Coin": {
+        "type": "object",
+        "required": [
+          "amount",
+          "denom"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          },
+          "denom": {
+            "type": "string"
+          }
+        }
       },
       "Empty": {
         "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
@@ -507,6 +586,10 @@
           }
         },
         "additionalProperties": false
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
       },
       "Uint64": {
         "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
@@ -858,6 +941,19 @@
                 "$ref": "#/definitions/Empty"
               }
             },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "get_withdraw_address"
+        ],
+        "properties": {
+          "get_withdraw_address": {
+            "type": "object",
             "additionalProperties": false
           }
         },
@@ -1385,6 +1481,11 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Null",
       "type": "null"
+    },
+    "get_withdraw_address": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "String",
+      "type": "string"
     },
     "minter": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/cw721-metadata-onchain/src/lib.rs
+++ b/contracts/cw721-metadata-onchain/src/lib.rs
@@ -48,7 +48,7 @@ pub mod entry {
         env: Env,
         info: MessageInfo,
         msg: InstantiateMsg,
-    ) -> StdResult<Response> {
+    ) -> Result<Response, ContractError> {
         cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
         Cw721MetadataContract::default().instantiate(deps.branch(), env, info, msg)
@@ -93,6 +93,7 @@ mod tests {
                 name: "".into(),
                 symbol: "".into(),
                 minter: "larry".into(),
+                withdraw_address: None,
             },
         )
         .unwrap();
@@ -112,6 +113,7 @@ mod tests {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
             minter: CREATOR.to_string(),
+            withdraw_address: None,
         };
         contract
             .instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg)

--- a/contracts/cw721-non-transferable/schema/instantiate_msg.json
+++ b/contracts/cw721-non-transferable/schema/instantiate_msg.json
@@ -22,6 +22,12 @@
     },
     "symbol": {
       "type": "string"
+    },
+    "withdraw_address": {
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
   "additionalProperties": false

--- a/contracts/cw721-non-transferable/src/lib.rs
+++ b/contracts/cw721-non-transferable/src/lib.rs
@@ -47,6 +47,7 @@ pub mod entry {
             name: msg.name,
             symbol: msg.symbol,
             minter: msg.minter,
+            withdraw_address: None,
         };
 
         Cw721NonTransferableContract::default().instantiate(

--- a/contracts/cw721-non-transferable/src/lib.rs
+++ b/contracts/cw721-non-transferable/src/lib.rs
@@ -47,7 +47,7 @@ pub mod entry {
             name: msg.name,
             symbol: msg.symbol,
             minter: msg.minter,
-            withdraw_address: None,
+            withdraw_address: msg.withdraw_address,
         };
 
         Cw721NonTransferableContract::default().instantiate(

--- a/contracts/cw721-non-transferable/src/msg.rs
+++ b/contracts/cw721-non-transferable/src/msg.rs
@@ -8,6 +8,7 @@ pub struct InstantiateMsg {
     pub name: String,
     pub symbol: String,
     pub minter: String,
+    pub withdraw_address: Option<String>,
 }
 
 #[cw_serde]


### PR DESCRIPTION
This feature adds an optional withdrawal address. Please note: existing 3rd party doesnt need  to update. Like it is still possible using old instantiate msg without defining a withdraw address!

This PR allows current NFT contracts to:
1. set and remove withdraw addresses by owner
2. withdraw funds by any to given address

This way launchpads, fee sharing, marketplaces etc. can benefit from this, like:
- by sending funds or royalties to nft contract where a creator on the other can withdraw them
- define other 3rd party contracts to withdraw funds

Added these new messages to cw721-base:

ExecuteMsg:

```rs
    /// Sets address to send withdrawn fees to. Only owner can call this.
    SetWithdrawAddress { address: String },
    /// Removes the withdraw address, so fees are sent to the contract. Only owner can call this.
    RemoveWithdrawAddress {},
    /// Withdraw from the contract to the given address. Anyone can call this,
    /// which is okay since withdraw address has been set by owner.
    WithdrawFunds { amount: Coin },
```

QueryMsg:

```rs
    #[returns(String)]
    GetWithdrawAddress {},
```