### PR TITLE
#151 make minter optional

### DIFF
--- a/contracts/cw2981-royalties/schema/cw2981-royalties.json
+++ b/contracts/cw2981-royalties/schema/cw2981-royalties.json
@@ -7,14 +7,16 @@
     "title": "InstantiateMsg",
     "type": "object",
     "required": [
-      "minter",
       "name",
       "symbol"
     ],
     "properties": {
       "minter": {
         "description": "The minter is the only one who can create new NFTs. This is designed for a base NFT that is controlled by an external program or contract. You will likely replace this with custom logic in custom NFTs",
-        "type": "string"
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "name": {
         "description": "Name of the NFT contract",

--- a/contracts/cw2981-royalties/src/lib.rs
+++ b/contracts/cw2981-royalties/src/lib.rs
@@ -136,7 +136,7 @@ mod tests {
         let init_msg = InstantiateMsg {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
-            minter: CREATOR.to_string(),
+            minter: None,
             withdraw_address: None,
         };
         entry::instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg).unwrap();
@@ -170,7 +170,7 @@ mod tests {
         let init_msg = InstantiateMsg {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
-            minter: CREATOR.to_string(),
+            minter: None,
             withdraw_address: None,
         };
         entry::instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg).unwrap();
@@ -201,7 +201,7 @@ mod tests {
         let init_msg = InstantiateMsg {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
-            minter: CREATOR.to_string(),
+            minter: None,
             withdraw_address: None,
         };
         entry::instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg).unwrap();
@@ -242,7 +242,7 @@ mod tests {
         let init_msg = InstantiateMsg {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
-            minter: CREATOR.to_string(),
+            minter: None,
             withdraw_address: None,
         };
         entry::instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg).unwrap();

--- a/contracts/cw721-base/schema/cw721-base.json
+++ b/contracts/cw721-base/schema/cw721-base.json
@@ -7,14 +7,16 @@
     "title": "InstantiateMsg",
     "type": "object",
     "required": [
-      "minter",
       "name",
       "symbol"
     ],
     "properties": {
       "minter": {
         "description": "The minter is the only one who can create new NFTs. This is designed for a base NFT that is controlled by an external program or contract. You will likely replace this with custom logic in custom NFTs",
-        "type": "string"
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "name": {
         "description": "Name of the NFT contract",

--- a/contracts/cw721-base/src/contract_tests.rs
+++ b/contracts/cw721-base/src/contract_tests.rs
@@ -24,7 +24,7 @@ fn setup_contract(deps: DepsMut<'_>) -> Cw721Contract<'static, Extension, Empty,
     let msg = InstantiateMsg {
         name: CONTRACT_NAME.to_string(),
         symbol: SYMBOL.to_string(),
-        minter: String::from(MINTER),
+        minter: Some(String::from(MINTER)),
         withdraw_address: None,
     };
     let info = mock_info("creator", &[]);
@@ -41,7 +41,7 @@ fn proper_instantiation() {
     let msg = InstantiateMsg {
         name: CONTRACT_NAME.to_string(),
         symbol: SYMBOL.to_string(),
-        minter: String::from(MINTER),
+        minter: Some(String::from(MINTER)),
         withdraw_address: Some(String::from(MINTER)),
     };
     let info = mock_info("creator", &[]);

--- a/contracts/cw721-base/src/lib.rs
+++ b/contracts/cw721-base/src/lib.rs
@@ -109,11 +109,17 @@ mod tests {
             InstantiateMsg {
                 name: "".into(),
                 symbol: "".into(),
-                minter: "larry".into(),
+                minter: Some("other".into()),
                 withdraw_address: None,
             },
         )
         .unwrap();
+
+        let minter = cw_ownable::get_ownership(deps.as_ref().storage)
+            .unwrap()
+            .owner
+            .map(|a| a.into_string());
+        assert_eq!(minter, Some("other".to_string()));
 
         let version = cw2::get_contract_version(deps.as_ref().storage).unwrap();
         assert_eq!(
@@ -123,5 +129,29 @@ mod tests {
                 version: CONTRACT_VERSION.into(),
             },
         );
+    }
+
+    #[test]
+    fn proper_owner_initialization() {
+        let mut deps = mock_dependencies();
+
+        entry::instantiate(
+            deps.as_mut(),
+            mock_env(),
+            mock_info("owner", &[]),
+            InstantiateMsg {
+                name: "".into(),
+                symbol: "".into(),
+                minter: None,
+                withdraw_address: None,
+            },
+        )
+        .unwrap();
+
+        let minter = cw_ownable::get_ownership(deps.as_ref().storage)
+            .unwrap()
+            .owner
+            .map(|a| a.into_string());
+        assert_eq!(minter, Some("owner".to_string()));
     }
 }

--- a/contracts/cw721-base/src/msg.rs
+++ b/contracts/cw721-base/src/msg.rs
@@ -14,7 +14,7 @@ pub struct InstantiateMsg {
     /// The minter is the only one who can create new NFTs.
     /// This is designed for a base NFT that is controlled by an external program
     /// or contract. You will likely replace this with custom logic in custom NFTs
-    pub minter: String,
+    pub minter: Option<String>,
 
     pub withdraw_address: Option<String>,
 }

--- a/contracts/cw721-expiration/schema/cw721-expiration.json
+++ b/contracts/cw721-expiration/schema/cw721-expiration.json
@@ -8,7 +8,6 @@
     "type": "object",
     "required": [
       "expiration_days",
-      "minter",
       "name",
       "symbol"
     ],
@@ -21,7 +20,10 @@
       },
       "minter": {
         "description": "The minter is the only one who can create new NFTs. This is designed for a base NFT that is controlled by an external program or contract. You will likely replace this with custom logic in custom NFTs",
-        "type": "string"
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "name": {
         "description": "Name of the NFT contract",

--- a/contracts/cw721-expiration/src/contract_tests.rs
+++ b/contracts/cw721-expiration/src/contract_tests.rs
@@ -29,7 +29,7 @@ fn setup_contract(deps: DepsMut<'_>, expiration_days: u16) -> Cw721ExpirationCon
         expiration_days,
         name: CONTRACT_NAME.to_string(),
         symbol: SYMBOL.to_string(),
-        minter: String::from(MINTER),
+        minter: Some(String::from(MINTER)),
         withdraw_address: None,
     };
     let info = mock_info("creator", &[]);
@@ -47,7 +47,7 @@ fn proper_instantiation() {
         expiration_days: 1,
         name: CONTRACT_NAME.to_string(),
         symbol: SYMBOL.to_string(),
-        minter: String::from(MINTER),
+        minter: Some(String::from(MINTER)),
         withdraw_address: None,
     };
     let info = mock_info("creator", &[]);

--- a/contracts/cw721-expiration/src/lib.rs
+++ b/contracts/cw721-expiration/src/lib.rs
@@ -86,7 +86,7 @@ mod tests {
                 expiration_days: 0,
                 name: "".into(),
                 symbol: "".into(),
-                minter: "mrt".into(),
+                minter: Some("mrt".into()),
                 withdraw_address: None,
             },
         )
@@ -102,7 +102,7 @@ mod tests {
                 expiration_days: 1,
                 name: "".into(),
                 symbol: "".into(),
-                minter: "mrt".into(),
+                minter: Some("mrt".into()),
                 withdraw_address: None,
             },
         )

--- a/contracts/cw721-expiration/src/msg.rs
+++ b/contracts/cw721-expiration/src/msg.rs
@@ -18,7 +18,7 @@ pub struct InstantiateMsg {
     /// The minter is the only one who can create new NFTs.
     /// This is designed for a base NFT that is controlled by an external program
     /// or contract. You will likely replace this with custom logic in custom NFTs
-    pub minter: String,
+    pub minter: Option<String>,
 
     pub withdraw_address: Option<String>,
 }

--- a/contracts/cw721-fixed-price/src/contract.rs
+++ b/contracts/cw721-fixed-price/src/contract.rs
@@ -26,7 +26,7 @@ const INSTANTIATE_TOKEN_REPLY_ID: u64 = 1;
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
     deps: DepsMut,
-    env: Env,
+    _env: Env,
     info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
@@ -61,7 +61,7 @@ pub fn instantiate(
             msg: to_json_binary(&Cw721InstantiateMsg {
                 name: msg.name.clone(),
                 symbol: msg.symbol,
-                minter: env.contract.address.to_string(),
+                minter: None,
                 withdraw_address: msg.withdraw_address,
             })?,
             funds: vec![],
@@ -228,7 +228,7 @@ mod tests {
                     msg: to_json_binary(&Cw721InstantiateMsg {
                         name: msg.name.clone(),
                         symbol: msg.symbol.clone(),
-                        minter: MOCK_CONTRACT_ADDR.to_string(),
+                        minter: None,
                         withdraw_address: None,
                     })
                     .unwrap(),

--- a/contracts/cw721-metadata-onchain/schema/cw721-metadata-onchain.json
+++ b/contracts/cw721-metadata-onchain/schema/cw721-metadata-onchain.json
@@ -7,14 +7,16 @@
     "title": "InstantiateMsg",
     "type": "object",
     "required": [
-      "minter",
       "name",
       "symbol"
     ],
     "properties": {
       "minter": {
         "description": "The minter is the only one who can create new NFTs. This is designed for a base NFT that is controlled by an external program or contract. You will likely replace this with custom logic in custom NFTs",
-        "type": "string"
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "name": {
         "description": "Name of the NFT contract",

--- a/contracts/cw721-metadata-onchain/src/lib.rs
+++ b/contracts/cw721-metadata-onchain/src/lib.rs
@@ -92,7 +92,7 @@ mod tests {
             InstantiateMsg {
                 name: "".into(),
                 symbol: "".into(),
-                minter: "larry".into(),
+                minter: None,
                 withdraw_address: None,
             },
         )
@@ -112,7 +112,7 @@ mod tests {
         let init_msg = InstantiateMsg {
             name: "SpaceShips".to_string(),
             symbol: "SPACE".to_string(),
-            minter: CREATOR.to_string(),
+            minter: None,
             withdraw_address: None,
         };
         contract

--- a/contracts/cw721-non-transferable/schema/instantiate_msg.json
+++ b/contracts/cw721-non-transferable/schema/instantiate_msg.json
@@ -3,7 +3,6 @@
   "title": "InstantiateMsg",
   "type": "object",
   "required": [
-    "minter",
     "name",
     "symbol"
   ],
@@ -15,7 +14,10 @@
       ]
     },
     "minter": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "name": {
       "type": "string"

--- a/contracts/cw721-non-transferable/src/msg.rs
+++ b/contracts/cw721-non-transferable/src/msg.rs
@@ -7,7 +7,7 @@ pub struct InstantiateMsg {
     pub admin: Option<String>,
     pub name: String,
     pub symbol: String,
-    pub minter: String,
+    pub minter: Option<String>,
     pub withdraw_address: Option<String>,
 }
 


### PR DESCRIPTION
PR for #151

Rather prefer having `minter: Option<String>`:
https://github.com/CosmWasm/cw-nfts/blob/177a993dfb5a1a3164be1baf274f43b1ca53da53/contracts/cw721-base/src/msg.rs#L8-L18

In case of none, `info.sender` should be minter. Makes it easier for other contracts (e.g. minter) re-using this msg.

In most cases creator of contract is also minter. Rn creator (=sender) instantiates contract AND need to provides its own address in `minter` prop. You can see this in unit tests:

Before: duplicate, since creator is in `info.sender` and `minter.prop`

```rust
        let info = mock_info(CREATOR, &[]);
        let init_msg = InstantiateMsg {
            name: "SpaceShips".to_string(),
            symbol: "SPACE".to_string(),
            minter: CREATOR.to_string(),
            withdraw_address: None,
        };
        entry::instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg).unwrap();
```

After: no need to provider `minter` prop, since creator is sender:

```rust
        let info = mock_info(CREATOR, &[]);
        let init_msg = InstantiateMsg {
            name: "SpaceShips".to_string(),
            symbol: "SPACE".to_string(),
            minter: None,
            withdraw_address: None,
        };
        entry::instantiate(deps.as_mut(), mock_env(), info.clone(), init_msg).unwrap();
```

Instantiation is like this then:

like before, in case caller should NOT be minter/owner (edge case):
```json
{"name": "foo", "symbol": "bar", "minter": "other_than_caller"}
```

for creator (standard, 99.99% case):
```json
{"name": "foo", "symbol": "bar"}
```


@shanev @JakeHartnell 