### PR TITLE
Fix optimizer call in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,8 @@ set -o errexit -o nounset -o pipefail
 command -v shellcheck >/dev/null && shellcheck "$0"
 
 cd "$(git rev-parse --show-toplevel)"
-docker run --rm -v "$(pwd)":/code --platform linux/amd64 \
-	--mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
+docker run --rm -v "$(pwd)":/code \
+	--mount type=volume,source="$(basename "$(pwd)")_cache",target=/target \
 	--mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-	cosmwasm/workspace-optimizer:0.16.0 # https://hub.docker.com/r/cosmwasm/workspace-optimizer/tags
+	cosmwasm/optimizer:0.16.0 # https://hub.docker.com/r/cosmwasm/optimizer/tags
 ls -al ./artifacts/*wasm


### PR DESCRIPTION
- Remove unneeded `--platform` arg (optimizer does not have multi-arch support in order to get better reproducibility. ARM images have a different name)
- Fix location of target folder to make build cache work again
- Use cosmwasm/optimizer image as cosmwasm/workspace-optimizer is a deprecated alias for that